### PR TITLE
Register more useful gyms

### DIFF
--- a/gym/cpr_gym/__init__.py
+++ b/gym/cpr_gym/__init__.py
@@ -6,7 +6,6 @@ from . import wrappers  # noqa
 
 # Link Python/OCaml bridge
 
-
 try:
     curdir = dir_path = os.path.dirname(os.path.realpath(__file__))
     dll_basename = "bridge.so"
@@ -18,12 +17,11 @@ try:
     argv = argv_t(dll_basename.encode("utf-8"), None)
     dll.caml_startup(argv)
 
-    # Register gym environments
-    gym.envs.register(id="core-v0", entry_point="cpr_gym.envs:Core")
-    gym.envs.register(id="cpr-v0", entry_point="cpr_gym.envs:env_fn")
-
     # Make dll-dependent modules available
     import engine, protocols  # noqa
+
+    # Register gym envs
+    from . import envs
 except OSError:
     if os.path.exists(dll_name):
         raise

--- a/gym/cpr_gym/__init__.py
+++ b/gym/cpr_gym/__init__.py
@@ -20,6 +20,7 @@ try:
 
     # Register gym environments
     gym.envs.register(id="core-v0", entry_point="cpr_gym.envs:Core")
+    gym.envs.register(id="cpr-v0", entry_point="cpr_gym.envs:env_fn")
 
     # Make dll-dependent modules available
     import engine, protocols  # noqa

--- a/gym/cpr_gym/envs.py
+++ b/gym/cpr_gym/envs.py
@@ -9,11 +9,28 @@ from . import wrappers
 class Core(gym.Env):
     metadata = {"render.modes": ["ascii"]}
 
-    def __init__(self, proto=protocols.nakamoto(), alpha=0.25, gamma=0.5, **kwargs):
+    def __init__(
+        self,
+        proto=protocols.nakamoto(),
+        alpha=0.25,
+        gamma=0.5,
+        activation_delay=1.0,
+        **kwargs,
+    ):
         self.core_kwargs = kwargs
         self.core_kwargs["proto"] = proto
         self.core_kwargs["alpha"] = alpha
         self.core_kwargs["gamma"] = gamma
+        self.core_kwargs["activation_delay"] = activation_delay
+
+        if (
+            "max_time" not in kwargs
+            and "max_progress" not in kwargs
+            and "max_steps" not in kwargs
+        ):
+            raise ValueError(
+                "cpr_gym: set at least one of kwargs max_progress, max_steps, and max_time."
+            )
 
         self.ocaml_env = None
         Core.reset(self)  # sets self.ocaml_env from self.core_kwargs

--- a/gym/cpr_gym/envs.py
+++ b/gym/cpr_gym/envs.py
@@ -2,6 +2,7 @@ import engine
 import gym
 import numpy as np
 import protocols
+from . import wrappers
 
 
 class Core(gym.Env):
@@ -50,3 +51,51 @@ class Core(gym.Env):
 
     def render(self, mode="ascii"):
         print(engine.to_string(self.ocaml_env))
+
+
+def env_fn(**config):
+    protocol_fn = getattr(protocols, config.get("protocol", "nakamoto"))
+    protocol_args = config.get("protocol_args", {})
+
+    episode_len = config.get("episode_len", 128)
+
+    alpha = config.get("alpha", 0.33)
+    gamma = config.get("gamma", 0.5)
+    if "defenders" in config:
+        defenders = config["defenders"]
+    else:
+        defenders = np.ceil((1 - alpha) / (1 - gamma))
+
+    rewards = dict(
+        sparse_relative=(
+            wrappers.SparseRelativeRewardWrapper,
+            dict(max_steps=episode_len),
+        ),
+        sparse_per_progress=(
+            wrappers.SparseRewardPerProgressWrapper,
+            dict(max_steps=episode_len),
+        ),
+        dense_per_progress=(
+            lambda env: wrappers.DenseRewardPerProgressWrapper(
+                env, episode_len=episode_len
+            ),
+            dict(),
+        ),
+    )
+
+    reward_wrapper, env_args = rewards[config.get("reward", "sparse_relative")]
+
+    env = Core(
+        proto=protocol_fn(**protocol_args),
+        alpha=alpha,
+        gamma=gamma,
+        defenders=defenders,
+        **env_args
+    )
+
+    env = reward_wrapper(env)
+
+    if config.get("normalize_reward", True):
+        env = wrappers.MapRewardWrapper(env, lambda r: r / alpha)
+
+    return env

--- a/gym/cpr_gym/envs.py
+++ b/gym/cpr_gym/envs.py
@@ -64,7 +64,7 @@ def env_fn(**config):
     if "defenders" in config:
         defenders = config["defenders"]
     else:
-        defenders = np.ceil((1 - alpha) / (1 - gamma))
+        defenders = int(np.ceil((1 - alpha) / (1 - gamma)))
 
     rewards = dict(
         sparse_relative=(

--- a/gym/cpr_gym/envs.py
+++ b/gym/cpr_gym/envs.py
@@ -2,15 +2,18 @@ import engine
 import gym
 import numpy as np
 import protocols
+import warnings
 from . import wrappers
 
 
 class Core(gym.Env):
     metadata = {"render.modes": ["ascii"]}
 
-    def __init__(self, proto=protocols.nakamoto(), **kwargs):
+    def __init__(self, proto=protocols.nakamoto(), alpha=0.25, gamma=0.5, **kwargs):
         self.core_kwargs = kwargs
         self.core_kwargs["proto"] = proto
+        self.core_kwargs["alpha"] = alpha
+        self.core_kwargs["gamma"] = gamma
 
         self.ocaml_env = None
         Core.reset(self)  # sets self.ocaml_env from self.core_kwargs
@@ -38,8 +41,20 @@ class Core(gym.Env):
             )
 
     def reset(self):
-        # TODO / ocaml: we could expose engine.init that combines create and reset
-        self.ocaml_env = engine.create(**self.core_kwargs)
+        kwargs = self.core_kwargs.copy()
+        d = kwargs.pop("defenders", None)
+        if d is None:
+            a = kwargs["alpha"]
+            g = kwargs["gamma"]
+            if g >= 1:
+                raise ValueError("gamma must be smaller than 1")
+            d = int(np.ceil((1 - a) / (1 - g)))
+            if d >= 100:
+                warnings.warn(
+                    f"Expensive assumptions: alpha={a} and gamma={g} imply defenders={d}"
+                )
+
+        self.ocaml_env = engine.create(defenders=d, **kwargs)
         obs = engine.reset(self.ocaml_env)
         obs = np.array(obs)  # for pickling; why doesn't pyml support pickling?
         return obs
@@ -63,6 +78,8 @@ def env_fn(
     episode_len=128,
     alpha=0.45,
     gamma=0.5,
+    pretend_alpha=None,
+    pretend_gamma=None,
     defenders=None,
     reward="sparse_relative",
     normalize_reward=True,
@@ -73,9 +90,6 @@ def env_fn(
         protocol_args = _protocol_args
     else:
         protocol_args = _protocol_args | protocol_args
-
-    if defenders is None:
-        defenders = int(np.ceil((1 - alpha) / (1 - gamma)))
 
     rewards = dict(
         sparse_relative=(
@@ -98,16 +112,26 @@ def env_fn(
 
     env = Core(
         proto=protocol_fn(**protocol_args),
+        alpha=0.0,  # set from wrapper below
+        gamma=0.0,  # set from wrapper below
+        defenders=defenders,
+        **env_args,
+    )
+
+    env = wrappers.AssumptionScheduleWrapper(
+        env,
         alpha=alpha,
         gamma=gamma,
-        defenders=defenders,
-        **env_args
+        pretend_alpha=pretend_alpha,
+        pretend_gamma=pretend_gamma,
     )
+
+    env.reset()  # set alpha and gamma from wrapper
 
     env = reward_wrapper(env)
 
     if normalize_reward:
-        env = wrappers.MapRewardWrapper(env, lambda r: r / alpha)
+        env = wrappers.MapRewardWrapper(env, lambda r, i: r / i["alpha"])
 
     return env
 

--- a/gym/cpr_gym/wrappers.py
+++ b/gym/cpr_gym/wrappers.py
@@ -153,6 +153,19 @@ class ExtendObservationWrapper(gym.Wrapper):
         return self.env.policy(obs, name)
 
 
+class MapRewardWrapper(gym.RewardWrapper):
+    """
+    Applies the given function to all rewards.
+    """
+
+    def __init__(self, env, fn):
+        super().__init__(env)
+        self.mrw_fn = fn
+
+    def reward(self, reward):
+        return self.mrw_fn(reward)
+
+
 class AlphaScheduleWrapper(gym.Wrapper):
     """
     Reconfigures alpha on each reset.

--- a/gym/tests/test_brigde.py
+++ b/gym/tests/test_brigde.py
@@ -2,14 +2,26 @@ from cpr_gym import engine, protocols
 
 
 def test_engine():
-    env = engine.create(proto=protocols.nakamoto())
+    env = engine.create(
+        proto=protocols.nakamoto(),
+        alpha=0.33,
+        gamma=0.5,
+        defenders=2,
+        activation_delay=1,
+    )
     obs = engine.reset(env)
     obs, rew, done, info = engine.step(env, 0)
     assert not done
 
 
 def test_engine_600steps():  # see if the engine works for 600 steps, the policy failed.
-    env = engine.create(proto=protocols.nakamoto())
+    env = engine.create(
+        proto=protocols.nakamoto(),
+        alpha=0.33,
+        gamma=0.5,
+        defenders=2,
+        activation_delay=1,
+    )
     obs = engine.reset(env)
     for i in range(600):
         obs, rew, done, info = engine.step(env, 3)

--- a/gym/tests/test_envs.py
+++ b/gym/tests/test_envs.py
@@ -47,7 +47,7 @@ def test_sparseRewardPerProgressWrapper():
 
 
 def test_denseRewardPerProgressWrapper():
-    env = gym.make("cpr_gym:core-v0")
+    env = gym.make("cpr_gym:core-v0", max_progress=float("inf"))
     env = wrappers.DenseRewardPerProgressWrapper(env, episode_len=32)
     check_env(env)
     for i in range(42):
@@ -117,7 +117,7 @@ def test_assumptionScheduleWrapper():
 
 
 def test_ExtendObservationWrapper():
-    env = gym.make("cpr_gym:core-v0")
+    env = gym.make("cpr_gym:core-v0", max_progress=100)
     was_n = len(env.observation_space.low)
 
     fields = []
@@ -131,7 +131,7 @@ def test_ExtendObservationWrapper():
 
 
 def test_EpisodeRecorderWrapper():
-    env = gym.make("cpr_gym:core-v0")
+    env = gym.make("cpr_gym:core-v0", max_progress=100)
     env = wrappers.EpisodeRecorderWrapper(env, n=10, info_keys=["head_height"])
     check_env(env)
     for i in range(42):
@@ -143,11 +143,6 @@ def test_EpisodeRecorderWrapper():
 
 
 def test_registered_envs(capsys):
-    env = gym.make("cpr_gym:cpr-v0")
-    env.render()
-    captured = capsys.readouterr().out.splitlines()[0]
-    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.45 attacker"
-
     env = gym.make("cpr_gym:cpr-nakamoto-v0")
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]

--- a/gym/tests/test_envs.py
+++ b/gym/tests/test_envs.py
@@ -109,3 +109,24 @@ def test_EpisodeRecorderWrapper():
     for entry in env.erw_history:
         assert "episode_reward" in entry.keys()
         assert "head_height" in entry.keys()
+
+
+def test_registered_envs(capsys):
+    env = gym.make("cpr_gym:cpr-v0")
+    env.render()
+    captured = capsys.readouterr().out.splitlines()[0]
+    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.45 attacker"
+
+    env = gym.make("cpr_gym:cpr-nakamoto-v0")
+    env.render()
+    captured = capsys.readouterr().out.splitlines()[0]
+    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.45 attacker"
+
+    env = gym.make("cpr_gym:cpr-tailstorm-v0")
+    env.render()
+    captured = capsys.readouterr().out.splitlines()[0]
+    assert captured == (
+        "Tailstorm with k=8, discount rewards, and "
+        "heuristic sub-block selection; "
+        "SSZ'16-like attack space; α=0.45 attacker"
+    )

--- a/gym/tests/test_protocols.py
+++ b/gym/tests/test_protocols.py
@@ -3,13 +3,13 @@ from cpr_gym import protocols
 
 
 def test_version():
-    env = gym.make("cpr_gym:core-v0")
+    env = gym.make("cpr_gym:core-v0", max_progress=42)
     assert isinstance(env.version, str)
     assert len(env.version) > 0
 
 
 def test_default(capsys):
-    env = gym.make("cpr_gym:core-v0")
+    env = gym.make("cpr_gym:core-v0", max_steps=1000)
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
     assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.25 attacker"
@@ -17,7 +17,12 @@ def test_default(capsys):
 
 def test_policies_honest():
     env = gym.make(
-        "cpr_gym:core-v0", proto=protocols.bk(k=8), alpha=0.33, gamma=0.2, defenders=2
+        "cpr_gym:core-v0",
+        proto=protocols.bk(k=8, reward="constant"),
+        alpha=0.33,
+        gamma=0.2,
+        defenders=2,
+        max_steps=10000,
     )
     obs = env.reset()
     for x in range(600):
@@ -26,7 +31,12 @@ def test_policies_honest():
 
 def test_policies_selfish():
     env = gym.make(
-        "cpr_gym:core-v0", proto=protocols.bk(k=8), alpha=0.33, gamma=0.5, defenders=3
+        "cpr_gym:core-v0",
+        proto=protocols.bk(k=8, reward="constant"),
+        alpha=0.33,
+        gamma=0.5,
+        defenders=3,
+        max_steps=10000,
     )
     obs = env.reset()
     for x in range(600):
@@ -40,6 +50,7 @@ def test_nakamoto(capsys):
         alpha=0.33,
         gamma=0.7,
         defenders=5,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
@@ -57,10 +68,11 @@ def test_nakamoto(capsys):
 def test_ethereum(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.ethereum(),
+        proto=protocols.ethereum(reward="discount"),
         alpha=0.13,
         gamma=0.9,
         defenders=10,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
@@ -82,10 +94,11 @@ def test_ethereum(capsys):
 def test_bk(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bk(k=42),
+        proto=protocols.bk(k=42, reward="constant"),
         alpha=0.33,
         gamma=0.3,
         defenders=4,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
@@ -108,10 +121,11 @@ def test_bk(capsys):
 def test_bkll(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bkll(k=17),
+        proto=protocols.bkll(k=17, reward="constant"),
         alpha=0.33,
         gamma=0.3,
         defenders=4,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
@@ -140,6 +154,7 @@ def test_tailstorm(capsys):
         alpha=0.33,
         gamma=0.8,
         defenders=5,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
@@ -162,10 +177,13 @@ def test_tailstorm(capsys):
 def test_tailstormll(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.tailstormll(k=13, reward="discount"),
+        proto=protocols.tailstormll(
+            k=13, reward="discount", subblock_selection="optimal"
+        ),
         alpha=0.33,
         gamma=0.8,
         defenders=5,
+        max_steps=10000,
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]

--- a/simulator/gym/bridge.ml
+++ b/simulator/gym/bridge.ml
@@ -43,39 +43,36 @@ let () =
     m
     "create"
     (let%map proto = keyword "proto" penv ~docstring:"OCaml gym protocol spec"
-     and alpha =
-       keyword "alpha" float ~docstring:"attacker's relative compute" ~default:0.25
+     and alpha = keyword "alpha" float ~docstring:"attacker's relative compute"
      and gamma =
        keyword
          "gamma"
          float
          ~docstring:"similar to gamma parameter in selfish mining literature"
-         ~default:0.5
-     and defenders = keyword "defenders" int ~docstring:"number of defenders" ~default:2
+     and defenders = keyword "defenders" int ~docstring:"number of defenders"
      and activation_delay =
        keyword
          "activation_delay"
          float
          ~docstring:"expected delay between two consecutive puzzle solutions"
-         ~default:1.
      and max_steps =
        keyword
          "max_steps"
          int
          ~docstring:"maximum number of attacker steps before terminating the simulation"
-         ~default:1000
+         ~default:max_int
      and max_progress =
        keyword
          "max_progress"
          float
          ~docstring:"maximum blockchain progress before terminating the simulation"
-         ~default:Float.infinity
+         ~default:infinity
      and max_time =
        keyword
          "max_time"
          float
          ~docstring:"maximum simulated time before terminating the simulation"
-         ~default:Float.infinity
+         ~default:infinity
      in
      let (Proto p) = proto in
      let config =
@@ -166,8 +163,6 @@ let () =
 ;;
 
 let () =
-  (* TODO read reward functions from module; choose default and document possible
-     values *)
   let open Cpr_protocols in
   let m = Py_module.create "protocols" in
   Py_module.set
@@ -177,17 +172,14 @@ let () =
   Py_module.set
     m
     "ethereum"
-    (let%map reward =
-       keyword "reward" string ~default:"discount" ~docstring:"reward function"
-     in
+    (let%map reward = keyword "reward" string ~docstring:"reward function" in
      let incentive_scheme = Options.of_string_exn Ethereum.incentive_schemes reward in
      fun () ->
        Proto (Engine.of_module (ethereum_ssz ~incentive_scheme)) |> python_of_protocol);
   Py_module.set
     m
     "bk"
-    (let%map reward =
-       keyword "reward" string ~default:"constant" ~docstring:"reward function"
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
      and k = keyword "k" int ~docstring:"puzzles per block" in
      let incentive_scheme = Options.of_string_exn Bk.incentive_schemes reward in
      fun () ->
@@ -195,8 +187,7 @@ let () =
   Py_module.set
     m
     "bkll"
-    (let%map reward =
-       keyword "reward" string ~default:"constant" ~docstring:"reward function"
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
      and k = keyword "k" int ~docstring:"puzzles per block" in
      let incentive_scheme = Options.of_string_exn Bkll.incentive_schemes reward in
      fun () ->
@@ -204,15 +195,10 @@ let () =
   Py_module.set
     m
     "tailstorm"
-    (let%map reward =
-       keyword "reward" string ~default:"constant" ~docstring:"reward function"
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
      and k = keyword "k" int ~docstring:"puzzles per block"
      and subblock_selection =
-       keyword
-         "subblock_selection"
-         string
-         ~default:"optimal"
-         ~docstring:"sub-block selection mechanism"
+       keyword "subblock_selection" string ~docstring:"sub-block selection mechanism"
      in
      let incentive_scheme = Options.of_string_exn Tailstorm.incentive_schemes reward
      and subblock_selection =
@@ -224,15 +210,10 @@ let () =
   Py_module.set
     m
     "tailstormll"
-    (let%map reward =
-       keyword "reward" string ~default:"constant" ~docstring:"reward function"
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
      and k = keyword "k" int ~docstring:"puzzles per block"
      and subblock_selection =
-       keyword
-         "subblock_selection"
-         string
-         ~default:"optimal"
-         ~docstring:"sub-block selection mechanism"
+       keyword "subblock_selection" string ~docstring:"sub-block selection mechanism"
      in
      let incentive_scheme = Options.of_string_exn Tailstormll.incentive_schemes reward
      and subblock_selection =


### PR DESCRIPTION
This PR add a generic `env_fn()` for creating sensible Gym environments from serializable input. Depending on the inputs, the function applies different wrappers automatically. It then registers this function as `cpr-v0` Gym environment. Unlike the old `core-v0` environment, `cpr-v0` can be used with external tools like `ray[rllib]` and `rl-zoo3`.

This PR also adds shortcuts to relevant pre-configured protocols.

The new envs automatically set the number of defenders depending on alpha and gamma.

### Examples
```python
gym.make("cpr_gym:cpr-v0", protocol="nakamoto", alpha=0.45, gamma=0.5) # default
gym.make("cpr_gym:cpr-nakamoto-v0") # shortcut for protocol=nakamoto
gym.make("cpr_gym:cpr-v0", alpha=lambda: random.uniform(0, 0.5), gamma=[0, 0.5, 0.9])
gym.make("cpr_gym:cpr-v0", reward="sparse_relative") # default
gym.make("cpr_gym:cpr-v0", reward="sparse_per_progress")
gym.make("cpr_gym:cpr-v0", reward="dense_per_progress")
gym.make("cpr_gym:cpr-v0", normalize_reward=True) # default; devide rewards by alpha
gym.make("cpr_gym:cpr-v0", protocol="tailstorm", protocol_args=dict(k=8, reward='discount', subblock_selection='heuristic'), reward="sparse_per_progress")
gym.make("cpr_gym:cpr-tailstorm-v0") # shortcut for previous line
gym.make("cpr_gym:cpr-tailstorm-v0", protocol_args=dict(reward='constant')) # inherits k=8 and heuristic sb-selection
```

