### PR TITLE
June tailstorm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup:
 	opam install . --deps-only --working-dir --yes
 
 dependencies:
-	opam exec dune build {cpr,cpr-dev}.opam
+	opam exec dune build cpr.opam cpr-dev.opam
 	opam install . --deps-only --working-dir
 
 _venv: requirements.txt

--- a/experiments/simulate/visualize.ml
+++ b/experiments/simulate/visualize.ml
@@ -113,8 +113,19 @@ let tasks_per_attack_space f n_activations incentive_scheme =
 
 let tasks_per_attack_space f i = List.concat_map (tasks_per_attack_space f i)
 
+module Protocols = struct
+  include Cpr_protocols
+
+  let nakamoto_ssz = nakamoto_ssz ~unit_observation:true
+  let ethereum_ssz = ethereum_ssz ~unit_observation:true
+  let bk_ssz = bk_ssz ~unit_observation:true
+  let bkll_ssz = bkll_ssz ~unit_observation:true
+  let tailstorm_ssz = tailstorm_ssz ~unit_observation:true
+  let tailstormll_ssz = tailstormll_ssz ~unit_observation:true
+end
+
 let tasks =
-  let open Cpr_protocols in
+  let open Protocols in
   let tailstorm = tailstorm ~subblock_selection:`Optimal
   and tailstorm_ssz = tailstorm_ssz ~subblock_selection:`Optimal
   and tailstormll = tailstormll ~subblock_selection:`Optimal

--- a/experiments/simulate/withholding.ml
+++ b/experiments/simulate/withholding.ml
@@ -53,11 +53,22 @@ let selfish_mining n_activations (AttackSpace (module A)) =
        alphas)
 ;;
 
+module Protocols = struct
+  open Cpr_protocols
+
+  let nakamoto_ssz = nakamoto_ssz ~unit_observation:true
+  let ethereum_ssz = ethereum_ssz ~unit_observation:true
+  let bk_ssz = bk_ssz ~unit_observation:true
+  let bkll_ssz = bkll_ssz ~unit_observation:true
+  let tailstorm_ssz = tailstorm_ssz ~unit_observation:true
+  let tailstormll_ssz = tailstormll_ssz ~unit_observation:true
+end
+
 (* Run all combinations of protocol, attack, network and block_interval. *)
 let tasks ~n_activations =
   let two_agents = two_agents n_activations
   and selfish_mining = selfish_mining n_activations in
-  let open Cpr_protocols in
+  let open Protocols in
   two_agents nakamoto_ssz
   @ selfish_mining nakamoto_ssz
   @ two_agents (ethereum_ssz ~incentive_scheme:`Discount)

--- a/gym/cpr_gym/envs.py
+++ b/gym/cpr_gym/envs.py
@@ -11,7 +11,7 @@ class Core(gym.Env):
 
     def __init__(
         self,
-        proto=protocols.nakamoto(),
+        proto=protocols.nakamoto(unit_observation=True),
         alpha=0.25,
         gamma=0.5,
         activation_delay=1.0,
@@ -99,7 +99,7 @@ gym.envs.register(id="core-v0", entry_point=Core)
 def env_fn(
     protocol="nakamoto",
     protocol_args=None,
-    _protocol_args=dict(),
+    _protocol_args=dict(unit_observation=True),
     episode_len=128,
     alpha=0.45,
     gamma=0.5,
@@ -168,7 +168,7 @@ gym.envs.register(
     entry_point=env_fn,
     kwargs=dict(
         protocol="nakamoto",
-        _protocol_args=dict(),
+        _protocol_args=dict(unit_observation=True),
         reward="sparse_relative",
     ),
 )
@@ -178,7 +178,12 @@ gym.envs.register(
     entry_point=env_fn,
     kwargs=dict(
         protocol="tailstorm",
-        _protocol_args=dict(k=8, reward="discount", subblock_selection="heuristic"),
+        _protocol_args=dict(
+            k=8,
+            reward="discount",
+            subblock_selection="heuristic",
+            unit_observation=True,
+        ),
         reward="sparse_per_progress",
     ),
 )

--- a/gym/tests/test_daa.py
+++ b/gym/tests/test_daa.py
@@ -11,7 +11,7 @@ def test_simple_daa():
     def env_with_activation_delay(x):
         env = gym.make(
             "cpr_gym:core-v0",
-            proto=protocols.nakamoto(),
+            proto=protocols.nakamoto(unit_observation=True),
             max_steps=100,
             alpha=1 / 3,
             gamma=0.5,
@@ -63,7 +63,7 @@ def test_max_time():
     target = 42 * 10
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.nakamoto(),
+        proto=protocols.nakamoto(unit_observation=True),
         max_time=target,
         max_steps=int(target * 2),  # set high enough such that max_time takes effect
         activation_delay=1,

--- a/gym/tests/test_engine.py
+++ b/gym/tests/test_engine.py
@@ -3,7 +3,7 @@ from cpr_gym import engine, protocols
 
 def test_engine():
     env = engine.create(
-        proto=protocols.nakamoto(),
+        proto=protocols.nakamoto(unit_observation=False),
         alpha=0.33,
         gamma=0.5,
         defenders=2,
@@ -14,9 +14,11 @@ def test_engine():
     assert not done
 
 
-def test_engine_600steps():  # see if the engine works for 600 steps, the policy failed.
+def test_engine_600steps():
+    # see if the engine works for 600 steps.
+    # We had some memory management (gc?) problems in the beginning.
     env = engine.create(
-        proto=protocols.nakamoto(),
+        proto=protocols.nakamoto(unit_observation=True),
         alpha=0.33,
         gamma=0.5,
         defenders=2,

--- a/gym/tests/test_envs.py
+++ b/gym/tests/test_envs.py
@@ -146,15 +146,17 @@ def test_registered_envs(capsys):
     env = gym.make("cpr_gym:cpr-nakamoto-v0")
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
-    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.45 attacker"
+    assert captured == (
+        "Nakamoto consensus; "
+        "SSZ'16 attack space with unit observations; α=0.45 attacker"
+    )
 
     env = gym.make("cpr_gym:cpr-tailstorm-v0")
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
     assert captured == (
-        "Tailstorm with k=8, discount rewards, and "
-        "heuristic sub-block selection; "
-        "SSZ'16-like attack space; α=0.45 attacker"
+        "Tailstorm with k=8, discount rewards, and heuristic sub-block selection; "
+        "SSZ'16-like attack space with unit observations; α=0.45 attacker"
     )
 
     env = gym.make(

--- a/gym/tests/test_protocols.py
+++ b/gym/tests/test_protocols.py
@@ -1,5 +1,6 @@
 import gym
 from cpr_gym import protocols
+from stable_baselines3.common.env_checker import check_env
 
 
 def test_version():
@@ -64,6 +65,8 @@ def test_nakamoto(capsys):
     for x in range(600):
         obs, _, _, _ = env.step(env.policy(obs, "eyal-sirer-2014"))
 
+    check_env(env)
+
 
 def test_ethereum(capsys):
     env = gym.make(
@@ -89,6 +92,8 @@ def test_ethereum(capsys):
     obs = env.reset()
     for x in range(600):
         obs, _, _, _ = env.step(env.policy(obs, "selfish_discard"))
+
+    check_env(env)
 
 
 def test_bk(capsys):
@@ -117,6 +122,8 @@ def test_bk(capsys):
 
     assert info["protocol_k"] == 42
 
+    check_env(env)
+
 
 def test_bkll(capsys):
     env = gym.make(
@@ -143,6 +150,8 @@ def test_bkll(capsys):
         obs, _, _, info = env.step(env.policy(obs, "selfish"))
 
     assert info["protocol_k"] == 17
+
+    check_env(env)
 
 
 def test_tailstorm(capsys):
@@ -173,6 +182,8 @@ def test_tailstorm(capsys):
 
     assert info["protocol_k"] == 13
 
+    check_env(env)
+
 
 def test_tailstormll(capsys):
     env = gym.make(
@@ -201,3 +212,34 @@ def test_tailstormll(capsys):
         obs, _, _, info = env.step(env.policy(obs, "override-catchup"))
 
     assert info["protocol_k"] == 13
+
+    check_env(env)
+
+
+def test_tailstormjune(capsys):
+    env = gym.make(
+        "cpr_gym:core-v0",
+        proto=protocols.tailstormjune(k=7, reward="discount"),
+        alpha=0.25,
+        gamma=0.7,
+        defenders=4,
+        max_steps=10000,
+    )
+    env.render()
+    captured = capsys.readouterr().out.splitlines()[0]
+    assert captured == (
+        "Tailstorm/ll (June '22 version) with k=7 and discount rewards; "
+        "SSZ'16-like attack space; α=0.25 attacker"
+    )
+
+    obs = env.reset()
+    for x in range(600):
+        obs, _, _, _ = env.step(env.policy(obs, "honest"))
+
+    obs = env.reset()
+    for x in range(600):
+        obs, _, _, info = env.step(env.policy(obs, "override-catchup"))
+
+    assert info["protocol_k"] == 7
+
+    check_env(env)

--- a/gym/tests/test_protocols.py
+++ b/gym/tests/test_protocols.py
@@ -13,13 +13,16 @@ def test_default(capsys):
     env = gym.make("cpr_gym:core-v0", max_steps=1000)
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
-    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.25 attacker"
+    assert captured == (
+        "Nakamoto consensus; "
+        "SSZ'16 attack space with unit observations; α=0.25 attacker"
+    )
 
 
 def test_policies_honest():
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bk(k=8, reward="constant"),
+        proto=protocols.bk(k=8, reward="constant", unit_observation=True),
         alpha=0.33,
         gamma=0.2,
         defenders=2,
@@ -33,7 +36,7 @@ def test_policies_honest():
 def test_policies_selfish():
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bk(k=8, reward="constant"),
+        proto=protocols.bk(k=8, reward="constant", unit_observation=True),
         alpha=0.33,
         gamma=0.5,
         defenders=3,
@@ -47,7 +50,7 @@ def test_policies_selfish():
 def test_nakamoto(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.nakamoto(),
+        proto=protocols.nakamoto(unit_observation=True),
         alpha=0.33,
         gamma=0.7,
         defenders=5,
@@ -55,7 +58,10 @@ def test_nakamoto(capsys):
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
-    assert captured == "Nakamoto consensus; SSZ'16 attack space; α=0.33 attacker"
+    assert captured == (
+        "Nakamoto consensus; "
+        "SSZ'16 attack space with unit observations; α=0.33 attacker"
+    )
 
     obs = env.reset()
     for x in range(600):
@@ -71,7 +77,7 @@ def test_nakamoto(capsys):
 def test_ethereum(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.ethereum(reward="discount"),
+        proto=protocols.ethereum(reward="discount", unit_observation=True),
         alpha=0.13,
         gamma=0.9,
         defenders=10,
@@ -82,7 +88,7 @@ def test_ethereum(capsys):
     assert captured == (
         "Ethereum with heaviest_chain-preference, work-progress, uncle cap 2, "
         "and discount-rewards; "
-        "SSZ'16-like attack space; α=0.13 attacker"
+        "SSZ'16-like attack space with unit observations; α=0.13 attacker"
     )
 
     obs = env.reset()
@@ -99,7 +105,7 @@ def test_ethereum(capsys):
 def test_bk(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bk(k=42, reward="constant"),
+        proto=protocols.bk(k=42, reward="constant", unit_observation=True),
         alpha=0.33,
         gamma=0.3,
         defenders=4,
@@ -107,9 +113,9 @@ def test_bk(capsys):
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
-    assert (
-        captured
-        == "Bₖ with k=42 and constant rewards; SSZ'16-like attack space; α=0.33 attacker"
+    assert captured == (
+        "Bₖ with k=42 and constant rewards; "
+        "SSZ'16-like attack space with unit observations; α=0.33 attacker"
     )
 
     obs = env.reset()
@@ -128,7 +134,7 @@ def test_bk(capsys):
 def test_bkll(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.bkll(k=17, reward="constant"),
+        proto=protocols.bkll(k=17, reward="constant", unit_observation=True),
         alpha=0.33,
         gamma=0.3,
         defenders=4,
@@ -136,9 +142,9 @@ def test_bkll(capsys):
     )
     env.render()
     captured = capsys.readouterr().out.splitlines()[0]
-    assert (
-        captured
-        == "Bₖ/ll with k=17 and constant rewards; SSZ'16-like attack space; α=0.33 attacker"
+    assert captured == (
+        "Bₖ/ll with k=17 and constant rewards; "
+        "SSZ'16-like attack space with unit observations; α=0.33 attacker"
     )
 
     obs = env.reset()
@@ -158,7 +164,10 @@ def test_tailstorm(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
         proto=protocols.tailstorm(
-            k=13, reward="discount", subblock_selection="heuristic"
+            k=13,
+            reward="discount",
+            subblock_selection="heuristic",
+            unit_observation=True,
         ),
         alpha=0.33,
         gamma=0.8,
@@ -169,7 +178,7 @@ def test_tailstorm(capsys):
     captured = capsys.readouterr().out.splitlines()[0]
     assert captured == (
         "Tailstorm with k=13, discount rewards, and heuristic sub-block selection; "
-        "SSZ'16-like attack space; α=0.33 attacker"
+        "SSZ'16-like attack space with unit observations; α=0.33 attacker"
     )
 
     obs = env.reset()
@@ -189,7 +198,7 @@ def test_tailstormll(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
         proto=protocols.tailstormll(
-            k=13, reward="discount", subblock_selection="optimal"
+            k=13, reward="discount", subblock_selection="optimal", unit_observation=True
         ),
         alpha=0.33,
         gamma=0.8,
@@ -200,7 +209,7 @@ def test_tailstormll(capsys):
     captured = capsys.readouterr().out.splitlines()[0]
     assert captured == (
         "Tailstorm/ll with k=13, discount rewards, and optimal sub-block selection; "
-        "SSZ'16-like attack space; α=0.33 attacker"
+        "SSZ'16-like attack space with unit observations; α=0.33 attacker"
     )
 
     obs = env.reset()
@@ -219,7 +228,7 @@ def test_tailstormll(capsys):
 def test_tailstormjune(capsys):
     env = gym.make(
         "cpr_gym:core-v0",
-        proto=protocols.tailstormjune(k=7, reward="discount"),
+        proto=protocols.tailstormjune(k=7, reward="discount", unit_observation=False),
         alpha=0.25,
         gamma=0.7,
         defenders=4,
@@ -229,7 +238,7 @@ def test_tailstormjune(capsys):
     captured = capsys.readouterr().out.splitlines()[0]
     assert captured == (
         "Tailstorm/ll (June '22 version) with k=7 and discount rewards; "
-        "SSZ'16-like attack space; α=0.25 attacker"
+        "SSZ'16-like attack space with raw observations; α=0.25 attacker"
     )
 
     obs = env.reset()

--- a/simulator/gym/cpr_gym_engine.ml
+++ b/simulator/gym/cpr_gym_engine.ml
@@ -221,5 +221,14 @@ let () =
      in
      fun () ->
        Proto (Engine.of_module (tailstormll_ssz ~subblock_selection ~incentive_scheme ~k))
+       |> python_of_protocol);
+  Py_module.set
+    m
+    "tailstormjune"
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
+     and k = keyword "k" int ~docstring:"puzzles per block" in
+     let incentive_scheme = Options.of_string_exn Tailstormll.incentive_schemes reward in
+     fun () ->
+       Proto (Engine.of_module (tailstormjune_ssz ~incentive_scheme ~k))
        |> python_of_protocol)
 ;;

--- a/simulator/gym/cpr_gym_engine.ml
+++ b/simulator/gym/cpr_gym_engine.ml
@@ -168,30 +168,58 @@ let () =
   Py_module.set
     m
     "nakamoto"
-    (Defunc.return (fun () -> Proto (Engine.of_module nakamoto_ssz) |> python_of_protocol));
+    (let%map unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
+     in
+     fun () ->
+       Proto (Engine.of_module (nakamoto_ssz ~unit_observation)) |> python_of_protocol);
   Py_module.set
     m
     "ethereum"
-    (let%map reward = keyword "reward" string ~docstring:"reward function" in
+    (let%map reward = keyword "reward" string ~docstring:"reward function"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
+     in
      let incentive_scheme = Options.of_string_exn Ethereum.incentive_schemes reward in
      fun () ->
-       Proto (Engine.of_module (ethereum_ssz ~incentive_scheme)) |> python_of_protocol);
+       Proto (Engine.of_module (ethereum_ssz ~unit_observation ~incentive_scheme))
+       |> python_of_protocol);
   Py_module.set
     m
     "bk"
     (let%map reward = keyword "reward" string ~docstring:"reward function"
-     and k = keyword "k" int ~docstring:"puzzles per block" in
+     and k = keyword "k" int ~docstring:"puzzles per block"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
+     in
      let incentive_scheme = Options.of_string_exn Bk.incentive_schemes reward in
      fun () ->
-       Proto (Engine.of_module (bk_ssz ~k ~incentive_scheme)) |> python_of_protocol);
+       Proto (Engine.of_module (bk_ssz ~unit_observation ~k ~incentive_scheme))
+       |> python_of_protocol);
   Py_module.set
     m
     "bkll"
     (let%map reward = keyword "reward" string ~docstring:"reward function"
-     and k = keyword "k" int ~docstring:"puzzles per block" in
+     and k = keyword "k" int ~docstring:"puzzles per block"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
+     in
      let incentive_scheme = Options.of_string_exn Bkll.incentive_schemes reward in
      fun () ->
-       Proto (Engine.of_module (bkll_ssz ~k ~incentive_scheme)) |> python_of_protocol);
+       Proto (Engine.of_module (bkll_ssz ~unit_observation ~k ~incentive_scheme))
+       |> python_of_protocol);
   Py_module.set
     m
     "tailstorm"
@@ -199,13 +227,20 @@ let () =
      and k = keyword "k" int ~docstring:"puzzles per block"
      and subblock_selection =
        keyword "subblock_selection" string ~docstring:"sub-block selection mechanism"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
      in
      let incentive_scheme = Options.of_string_exn Tailstorm.incentive_schemes reward
      and subblock_selection =
        Options.of_string_exn Tailstorm.subblock_selections subblock_selection
      in
      fun () ->
-       Proto (Engine.of_module (tailstorm_ssz ~subblock_selection ~incentive_scheme ~k))
+       Proto
+         (Engine.of_module
+            (tailstorm_ssz ~unit_observation ~subblock_selection ~incentive_scheme ~k))
        |> python_of_protocol);
   Py_module.set
     m
@@ -214,21 +249,34 @@ let () =
      and k = keyword "k" int ~docstring:"puzzles per block"
      and subblock_selection =
        keyword "subblock_selection" string ~docstring:"sub-block selection mechanism"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
      in
      let incentive_scheme = Options.of_string_exn Tailstormll.incentive_schemes reward
      and subblock_selection =
        Options.of_string_exn Tailstormll.subblock_selections subblock_selection
      in
      fun () ->
-       Proto (Engine.of_module (tailstormll_ssz ~subblock_selection ~incentive_scheme ~k))
+       Proto
+         (Engine.of_module
+            (tailstormll_ssz ~unit_observation ~subblock_selection ~incentive_scheme ~k))
        |> python_of_protocol);
   Py_module.set
     m
     "tailstormjune"
     (let%map reward = keyword "reward" string ~docstring:"reward function"
-     and k = keyword "k" int ~docstring:"puzzles per block" in
+     and k = keyword "k" int ~docstring:"puzzles per block"
+     and unit_observation =
+       keyword
+         "unit_observation"
+         bool
+         ~docstring:"Whether to map the observation space to [0,1]^n or not"
+     in
      let incentive_scheme = Options.of_string_exn Tailstormll.incentive_schemes reward in
      fun () ->
-       Proto (Engine.of_module (tailstormjune_ssz ~incentive_scheme ~k))
+       Proto (Engine.of_module (tailstormjune_ssz ~unit_observation ~incentive_scheme ~k))
        |> python_of_protocol)
 ;;

--- a/simulator/gym/engine.ml
+++ b/simulator/gym/engine.ml
@@ -242,8 +242,6 @@ let of_module ?(logger = Log.dummy_logger) (AttackSpace (module M)) (p : Paramet
     t.last_progress <- progress;
     (* return *)
     observe (Instance t), reward, done_, info
-  and low = Float.Array.make M.Observation.length 0.
-  and high = Float.Array.make M.Observation.length 1.
   and to_string t =
     Printf.sprintf
       "%s; %s; α=%.2f attacker\n%s\nActions: %s"
@@ -262,8 +260,8 @@ let of_module ?(logger = Log.dummy_logger) (AttackSpace (module M)) (p : Paramet
   ; create
   ; reset
   ; step
-  ; low
-  ; high
+  ; low = M.Observation.low
+  ; high = M.Observation.high
   ; to_string
   ; policies
   }

--- a/simulator/lib/intf.ml
+++ b/simulator/lib/intf.ml
@@ -183,12 +183,16 @@ module type AttackSpace = sig
     type t
 
     val length : int
+    val low : floatarray
+    val high : floatarray
 
-    (* must return floats ranging from 0. to 1. *)
+    (** Encode observation in floatarray of size {!length} for machine observation.
+       Result must fall into the range provided by {!low} and {!high}. *)
     val to_floatarray : t -> floatarray
 
-    (* may assume floats ranging from 0. to 1. *)
+    (** Recover observation from floatarray created with {!to_floatarray}. *)
     val of_floatarray : floatarray -> t
+
     val to_string : t -> string
   end
 

--- a/simulator/protocols/bk_ssz.ml
+++ b/simulator/protocols/bk_ssz.ml
@@ -1,12 +1,22 @@
 open Cpr_lib
 
-module Make (Parameters : Bk.Parameters) = struct
+module type Parameters = sig
+  include Bk.Parameters
+  include Nakamoto_ssz.Parameters
+end
+
+module Make (Parameters : Parameters) = struct
   open Parameters
   module Protocol = Bk.Make (Parameters)
   open Protocol
 
-  let key = "ssz"
-  let info = "SSZ'16-like attack space"
+  let key = Format.asprintf "ssz-%s" (if unit_observation then "unitobs" else "rawobs")
+
+  let info =
+    Format.asprintf
+      "SSZ'16-like attack space with %s observations"
+      (if unit_observation then "unit" else "raw")
+  ;;
 
   module Observation = struct
     type t =
@@ -39,13 +49,38 @@ module Make (Parameters : Bk.Parameters) = struct
 
     let length = List.length Fields.names
 
+    let low, high =
+      let low, high = Float.Array.make length 0., Float.Array.make length 0. in
+      let set spec i _field =
+        let l, h = Ssz_tools.NormalizeObs.range ~unit:unit_observation spec in
+        Float.Array.set low i l;
+        Float.Array.set high i h;
+        i + 1
+      in
+      let _ =
+        let open Normalizers in
+        Fields.fold
+          ~init:0
+          ~public_blocks:(set public_blocks)
+          ~private_blocks:(set private_blocks)
+          ~diff_blocks:(set diff_blocks)
+          ~public_votes:(set public_votes)
+          ~private_votes_inclusive:(set private_votes_inclusive)
+          ~private_votes_exclusive:(set private_votes_exclusive)
+          ~lead:(set lead)
+          ~event:(set event)
+      in
+      low, high
+    ;;
+
     let to_floatarray t =
       let a = Float.Array.make length Float.nan in
       let set spec i field =
         Float.Array.set
           a
           i
-          (Fieldslib.Field.get field t |> Ssz_tools.NormalizeObs.to_float spec);
+          (Fieldslib.Field.get field t
+          |> Ssz_tools.NormalizeObs.to_float ~unit:unit_observation spec);
         i + 1
       in
       let _ =
@@ -66,7 +101,10 @@ module Make (Parameters : Bk.Parameters) = struct
 
     let of_floatarray =
       let get spec _ i =
-        (fun a -> Float.Array.get a i |> Ssz_tools.NormalizeObs.of_float spec), i + 1
+        ( (fun a ->
+            Float.Array.get a i
+            |> Ssz_tools.NormalizeObs.of_float ~unit:unit_observation spec)
+        , i + 1 )
       in
       let open Normalizers in
       fst

--- a/simulator/protocols/bkll_ssz.ml
+++ b/simulator/protocols/bkll_ssz.ml
@@ -1,12 +1,22 @@
 open Cpr_lib
 
-module Make (Parameters : Bkll.Parameters) = struct
+module type Parameters = sig
+  include Bk.Parameters
+  include Nakamoto_ssz.Parameters
+end
+
+module Make (Parameters : Parameters) = struct
   open Parameters
   module Protocol = Bkll.Make (Parameters)
   open Protocol
 
-  let key = "ssz"
-  let info = "SSZ'16-like attack space"
+  let key = Format.asprintf "ssz-%s" (if unit_observation then "unitobs" else "rawobs")
+
+  let info =
+    Format.asprintf
+      "SSZ'16-like attack space with %s observations"
+      (if unit_observation then "unit" else "raw")
+  ;;
 
   module Observation = struct
     type t =
@@ -38,13 +48,37 @@ module Make (Parameters : Bkll.Parameters) = struct
 
     let length = List.length Fields.names
 
+    let low, high =
+      let low, high = Float.Array.make length 0., Float.Array.make length 0. in
+      let set spec i _field =
+        let l, h = Ssz_tools.NormalizeObs.range ~unit:unit_observation spec in
+        Float.Array.set low i l;
+        Float.Array.set high i h;
+        i + 1
+      in
+      let _ =
+        let open Normalizers in
+        Fields.fold
+          ~init:0
+          ~public_blocks:(set public_blocks)
+          ~private_blocks:(set private_blocks)
+          ~diff_blocks:(set diff_blocks)
+          ~public_votes:(set public_votes)
+          ~private_votes_inclusive:(set private_votes_inclusive)
+          ~private_votes_exclusive:(set private_votes_exclusive)
+          ~event:(set event)
+      in
+      low, high
+    ;;
+
     let to_floatarray t =
       let a = Float.Array.make length Float.nan in
       let set spec i field =
         Float.Array.set
           a
           i
-          (Fieldslib.Field.get field t |> Ssz_tools.NormalizeObs.to_float spec);
+          (Fieldslib.Field.get field t
+          |> Ssz_tools.NormalizeObs.to_float ~unit:unit_observation spec);
         i + 1
       in
       let _ =
@@ -64,7 +98,10 @@ module Make (Parameters : Bkll.Parameters) = struct
 
     let of_floatarray =
       let get spec _ i =
-        (fun a -> Float.Array.get a i |> Ssz_tools.NormalizeObs.of_float spec), i + 1
+        ( (fun a ->
+            Float.Array.get a i
+            |> Ssz_tools.NormalizeObs.of_float ~unit:unit_observation spec)
+        , i + 1 )
       in
       let open Normalizers in
       fst

--- a/simulator/protocols/cpr_protocols.ml
+++ b/simulator/protocols/cpr_protocols.ml
@@ -12,7 +12,14 @@ let nakamoto = Protocol (module Nakamoto)
 (** Attack space against {!nakamoto} as described by Sapirshtein, Sompolinsky, and Zohar.
     Optimal Selfish Mining Strategies in Bitcoin. 2016.
     {{:https://arxiv.org/abs/1507.06183}Paper.} *)
-let nakamoto_ssz = AttackSpace (module Nakamoto_ssz)
+let nakamoto_ssz ~unit_observation:uo =
+  let module M =
+    Nakamoto_ssz.Make (struct
+      let unit_observation = uo
+    end)
+  in
+  AttackSpace (module M)
+;;
 
 (** Simplified version of GHOST as used in the Ethereum Platform *)
 let ethereum ~incentive_scheme:is =
@@ -28,12 +35,13 @@ let ethereum ~incentive_scheme:is =
 ;;
 
 (** {!nakamoto_ssz} adapted for Ethereum. *)
-let ethereum_ssz ~incentive_scheme:is =
+let ethereum_ssz ~unit_observation:uo ~incentive_scheme:is =
   let module M =
     Ethereum_ssz.Make (struct
       include Ethereum.Byzantium
 
       let incentive_scheme = is
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -52,11 +60,12 @@ let bk ~k ~incentive_scheme =
 ;;
 
 (** {!nakamoto_ssz} adapted for Bₖ. *)
-let bk_ssz ~k ~incentive_scheme =
+let bk_ssz ~unit_observation:uo ~k ~incentive_scheme =
   let module M =
     Bk_ssz.Make (struct
       let k = k
       let incentive_scheme = incentive_scheme
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -75,11 +84,12 @@ let bkll ~k ~incentive_scheme =
 ;;
 
 (** {!nakamoto_ssz} adapted for {!bkll}. *)
-let bkll_ssz ~k ~incentive_scheme =
+let bkll_ssz ~unit_observation:uo ~k ~incentive_scheme =
   let module M =
     Bkll_ssz.Make (struct
       let k = k
       let incentive_scheme = incentive_scheme
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -98,12 +108,13 @@ let tailstorm ~k ~incentive_scheme ~subblock_selection =
 ;;
 
 (** {!nakamoto_ssz} adapted for {!tailstorm}. *)
-let tailstorm_ssz ~k ~incentive_scheme ~subblock_selection =
+let tailstorm_ssz ~unit_observation:uo ~k ~incentive_scheme ~subblock_selection =
   let module M =
     Tailstorm_ssz.Make (struct
       let k = k
       let incentive_scheme = incentive_scheme
       let subblock_selection = subblock_selection
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -124,12 +135,13 @@ let tailstormll ~k ~incentive_scheme ~subblock_selection =
 ;;
 
 (** {!nakamoto_ssz} adapted for {!tailstormll}. *)
-let tailstormll_ssz ~k ~incentive_scheme ~subblock_selection =
+let tailstormll_ssz ~unit_observation:uo ~k ~incentive_scheme ~subblock_selection =
   let module M =
     Tailstormll_ssz.Make (struct
       let k = k
       let incentive_scheme = incentive_scheme
       let subblock_selection = subblock_selection
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -147,11 +159,12 @@ let tailstormjune ~k ~incentive_scheme =
 ;;
 
 (** {!nakamoto_ssz} adapted for {!tailstormjune}. *)
-let tailstormjune_ssz ~k ~incentive_scheme =
+let tailstormjune_ssz ~unit_observation:uo ~k ~incentive_scheme =
   let module M =
     Tailstorm_june_ssz.Make (struct
       let k = k
       let incentive_scheme = incentive_scheme
+      let unit_observation = uo
     end)
   in
   AttackSpace (module M)
@@ -461,6 +474,13 @@ let%test_module "policy" =
       else ()
     ;;
 
+    let nakamoto_ssz = nakamoto_ssz ~unit_observation:true
+    let ethereum_ssz = ethereum_ssz ~unit_observation:true
+    let bk_ssz = bk_ssz ~unit_observation:true
+    let bkll_ssz = bkll_ssz ~unit_observation:true
+    let tailstorm_ssz = tailstorm_ssz ~unit_observation:true
+    let tailstormll_ssz = tailstormll_ssz ~unit_observation:true
+    let tailstormjune_ssz = tailstormjune_ssz ~unit_observation:false
     let n = "nakamoto/ssz/honest"
 
     let%test_unit [%name n] = test n ~policy:"honest" ~orphan_rate_limit:0.01 nakamoto_ssz
@@ -611,6 +631,13 @@ let%test_module "random" =
       else ()
     ;;
 
+    let nakamoto_ssz = nakamoto_ssz ~unit_observation:true
+    let ethereum_ssz = ethereum_ssz ~unit_observation:true
+    let bk_ssz = bk_ssz ~unit_observation:true
+    let bkll_ssz = bkll_ssz ~unit_observation:true
+    let tailstorm_ssz = tailstorm_ssz ~unit_observation:true
+    let tailstormll_ssz = tailstormll_ssz ~unit_observation:true
+    let tailstormjune_ssz = tailstormjune_ssz ~unit_observation:false
     let n = "nakamoto/random"
 
     let%test_unit [%name n] = test n nakamoto_ssz

--- a/simulator/protocols/nakamoto_ssz.ml
+++ b/simulator/protocols/nakamoto_ssz.ml
@@ -1,311 +1,351 @@
 open Cpr_lib
-module Protocol = Nakamoto
-open Protocol
 
-let key = "ssz"
-let info = "SSZ'16 attack space"
+module type Parameters = sig
+  (** [false]: Maintain natural scale of observation floatarray.
 
-module Observation = struct
-  type t =
-    { public_blocks : int (** number of public blocks after common ancestor *)
-    ; private_blocks : int (** number of private blocks after common ancestor *)
-    ; diff_blocks : int (** private_blocks - public_blocks *)
-    ; event : [ `ProofOfWork | `Network ] (* What is currently going on? *)
-    }
-  [@@deriving fields]
-
-  module Normalizers = struct
-    open Ssz_tools.NormalizeObs
-
-    let public_blocks = UnboundedInt { non_negative = true; scale = 1 }
-    let private_blocks = UnboundedInt { non_negative = true; scale = 1 }
-    let diff_blocks = UnboundedInt { non_negative = false; scale = 1 }
-    let event = Discrete [ `ProofOfWork; `Network ]
-  end
-
-  let length = List.length Fields.names
-
-  let to_floatarray t =
-    let a = Float.Array.make length Float.nan in
-    let set spec i field =
-      Float.Array.set
-        a
-        i
-        (Fieldslib.Field.get field t |> Ssz_tools.NormalizeObs.to_float spec);
-      i + 1
-    in
-    let _ =
-      let open Normalizers in
-      Fields.fold
-        ~init:0
-        ~public_blocks:(set public_blocks)
-        ~private_blocks:(set private_blocks)
-        ~diff_blocks:(set diff_blocks)
-        ~event:(set event)
-    in
-    a
-  ;;
-
-  let of_floatarray =
-    let get spec _ i =
-      (fun a -> Float.Array.get a i |> Ssz_tools.NormalizeObs.of_float spec), i + 1
-    in
-    let open Normalizers in
-    fst
-      (Fields.make_creator
-         0
-         ~public_blocks:(get public_blocks)
-         ~private_blocks:(get private_blocks)
-         ~diff_blocks:(get diff_blocks)
-         ~event:(get event))
-  ;;
-
-  let to_string t =
-    let conv to_s field =
-      Printf.sprintf
-        "%s: %s"
-        (Fieldslib.Field.name field)
-        (to_s (Fieldslib.Field.get field t))
-    in
-    let int = conv string_of_int in
-    let event = conv Ssz_tools.event_to_string in
-    Fields.to_list ~public_blocks:int ~private_blocks:int ~diff_blocks:int ~event
-    |> String.concat "\n"
-  ;;
+      [true]: Map observation floatarray to [0,1]{^n}. *)
+  val unit_observation : bool
 end
 
-module Action = struct
-  type t =
-    | Adopt
-        (** Adopt the defender's preferred chain as attacker's preferred chain. Withheld
+module Make (Parameters : Parameters) = struct
+  open Parameters
+  module Protocol = Nakamoto
+  open Protocol
+
+  let key = Format.asprintf "ssz-%s" (if unit_observation then "unitobs" else "rawobs")
+
+  let info =
+    Format.asprintf
+      "SSZ'16 attack space with %s observations"
+      (if unit_observation then "unit" else "raw")
+  ;;
+
+  module Observation = struct
+    type t =
+      { public_blocks : int (** number of public blocks after common ancestor *)
+      ; private_blocks : int (** number of private blocks after common ancestor *)
+      ; diff_blocks : int (** private_blocks - public_blocks *)
+      ; event : [ `ProofOfWork | `Network ] (* What is currently going on? *)
+      }
+    [@@deriving fields]
+
+    module Normalizers = struct
+      open Ssz_tools.NormalizeObs
+
+      let public_blocks = UnboundedInt { non_negative = true; scale = 1 }
+      let private_blocks = UnboundedInt { non_negative = true; scale = 1 }
+      let diff_blocks = UnboundedInt { non_negative = false; scale = 1 }
+      let event = Discrete [ `ProofOfWork; `Network ]
+    end
+
+    let length = List.length Fields.names
+
+    let low, high =
+      let low, high = Float.Array.make length 0., Float.Array.make length 0. in
+      let set spec i _field =
+        let l, h = Ssz_tools.NormalizeObs.range ~unit:unit_observation spec in
+        Float.Array.set low i l;
+        Float.Array.set high i h;
+        i + 1
+      in
+      let _ =
+        let open Normalizers in
+        Fields.fold
+          ~init:0
+          ~public_blocks:(set public_blocks)
+          ~private_blocks:(set private_blocks)
+          ~diff_blocks:(set diff_blocks)
+          ~event:(set event)
+      in
+      low, high
+    ;;
+
+    let to_floatarray t =
+      let a = Float.Array.make length Float.nan in
+      let set spec i field =
+        Float.Array.set
+          a
+          i
+          (Fieldslib.Field.get field t
+          |> Ssz_tools.NormalizeObs.to_float ~unit:unit_observation spec);
+        i + 1
+      in
+      let _ =
+        let open Normalizers in
+        Fields.fold
+          ~init:0
+          ~public_blocks:(set public_blocks)
+          ~private_blocks:(set private_blocks)
+          ~diff_blocks:(set diff_blocks)
+          ~event:(set event)
+      in
+      a
+    ;;
+
+    let of_floatarray =
+      let get spec _ i =
+        ( (fun a ->
+            Float.Array.get a i
+            |> Ssz_tools.NormalizeObs.of_float ~unit:unit_observation spec)
+        , i + 1 )
+      in
+      let open Normalizers in
+      fst
+        (Fields.make_creator
+           0
+           ~public_blocks:(get public_blocks)
+           ~private_blocks:(get private_blocks)
+           ~diff_blocks:(get diff_blocks)
+           ~event:(get event))
+    ;;
+
+    let to_string t =
+      let conv to_s field =
+        Printf.sprintf
+          "%s: %s"
+          (Fieldslib.Field.name field)
+          (to_s (Fieldslib.Field.get field t))
+      in
+      let int = conv string_of_int in
+      let event = conv Ssz_tools.event_to_string in
+      Fields.to_list ~public_blocks:int ~private_blocks:int ~diff_blocks:int ~event
+      |> String.concat "\n"
+    ;;
+  end
+
+  module Action = struct
+    type t =
+      | Adopt
+          (** Adopt the defender's preferred chain as attacker's preferred chain. Withheld
             attacker blocks are discarded.
 
             Equivalent to SSZ'16 model. *)
-    | Override
-        (** Publish just enough information to make the defender adopt the chain just
+      | Override
+          (** Publish just enough information to make the defender adopt the chain just
             released. The attacker continues mining the private chain.
 
             If override is impossible, this still results in a release of withheld
             information.
 
             Equivalent to SSZ'16 model. *)
-    | Match
-        (** Publish just enough information such that the defender observes a tie between
+      | Match
+          (** Publish just enough information such that the defender observes a tie between
             two chains. The attacker continues mining the private chain.
 
             If match is impossible, this still results in a release of withheld
             information.
 
             Equivalent to SSZ'16 model. *)
-    | Wait (** Continue withholding. Always possible. Equivalent to SSZ'16 model. *)
-  [@@deriving variants]
+      | Wait (** Continue withholding. Always possible. Equivalent to SSZ'16 model. *)
+    [@@deriving variants]
 
-  let to_string = Variants.to_name
-  let to_int = Variants.to_rank
+    let to_string = Variants.to_name
+    let to_int = Variants.to_rank
 
-  let table =
-    let add acc var = var.Variantslib.Variant.constructor :: acc in
-    Variants.fold ~init:[] ~adopt:add ~override:add ~match_:add ~wait:add
-    |> List.rev
-    |> Array.of_list
-  ;;
+    let table =
+      let add acc var = var.Variantslib.Variant.constructor :: acc in
+      Variants.fold ~init:[] ~adopt:add ~override:add ~match_:add ~wait:add
+      |> List.rev
+      |> Array.of_list
+    ;;
 
-  let of_int i = table.(i)
-  let n = Array.length table
-end
+    let of_int i = table.(i)
+    let n = Array.length table
+  end
 
-module Agent (V : View with type data = data) = struct
-  include V
-  module N = Honest (V)
+  module Agent (V : View with type data = data) = struct
+    include V
+    module N = Honest (V)
 
-  type state =
-    | BetweenActions of
-        { public : block (* defender's preferred block *)
-        ; private_ : block (* attacker's preferred block *)
-        ; pending_private_to_public_messages :
-            block list (* messages sent with last action *)
-        }
+    type state =
+      | BetweenActions of
+          { public : block (* defender's preferred block *)
+          ; private_ : block (* attacker's preferred block *)
+          ; pending_private_to_public_messages :
+              block list (* messages sent with last action *)
+          }
 
-  type state_before_action =
-    | BeforeAction of
-        { public : block
-        ; private_ : block
-        }
+    type state_before_action =
+      | BeforeAction of
+          { public : block
+          ; private_ : block
+          }
 
-  type observable_state =
-    | Observable of
-        { public : block
-        ; private_ : block
-        ; common : block
-        ; event : [ `ProofOfWork | `Network ]
-        }
+    type observable_state =
+      | Observable of
+          { public : block
+          ; private_ : block
+          ; common : block
+          ; event : [ `ProofOfWork | `Network ]
+          }
 
-  let init ~roots =
-    let root = N.init ~roots in
-    BetweenActions
-      { private_ = root; public = root; pending_private_to_public_messages = [] }
-  ;;
+    let init ~roots =
+      let root = N.init ~roots in
+      BetweenActions
+        { private_ = root; public = root; pending_private_to_public_messages = [] }
+    ;;
 
-  let preferred (BetweenActions s) = s.private_
-  let puzzle_payload (BetweenActions s) = N.puzzle_payload s.private_
+    let preferred (BetweenActions s) = s.private_
+    let puzzle_payload (BetweenActions s) = N.puzzle_payload s.private_
 
-  let deliver_private_to_public_messages (BetweenActions state) =
-    let public =
-      List.fold_left
-        (fun old consider -> N.update_head ~old consider)
-        state.public
-        state.pending_private_to_public_messages
-    in
-    BeforeAction { public; private_ = state.private_ }
-  ;;
-
-  module Dagtools = Dagtools.Make (Block)
-
-  let prepare (BeforeAction state) event =
-    let public, private_, event =
-      match event with
-      | Append _ -> failwith "not implemented"
-      | Network x ->
-        (* simulate defender *)
-        N.update_head ~old:state.public x, state.private_, `Network
-      | ProofOfWork x ->
-        (* work on private chain *)
-        state.public, x, `ProofOfWork
-    in
-    let common = Dagtools.common_ancestor public private_ |> Option.get in
-    Observable { public; private_; common; event }
-  ;;
-
-  let prepare state = deliver_private_to_public_messages state |> prepare
-
-  let observe (Observable state) =
-    let open Observation in
-    let ca_height = data state.common |> height
-    and private_height = data state.private_ |> height
-    and public_height = data state.public |> height in
-    { private_blocks = private_height - ca_height
-    ; public_blocks = public_height - ca_height
-    ; diff_blocks = private_height - public_height
-    ; event = state.event
-    }
-  ;;
-
-  let apply (Observable state) action =
-    let parent vtx =
-      match parents vtx with
-      | [ x ] -> Some x
-      | _ -> None
-    in
-    let match_ offset =
-      let h =
-        (* height of to be released block *)
-        height (data state.public) + offset
+    let deliver_private_to_public_messages (BetweenActions state) =
+      let public =
+        List.fold_left
+          (fun old consider -> N.update_head ~old consider)
+          state.public
+          state.pending_private_to_public_messages
       in
-      (* look for to be released block backwards from private head *)
-      let rec f b = if height (data b) <= h then b else parent b |> Option.get |> f in
-      [ f state.private_ ]
-      (* NOTE: if private height is smaller target height, then private head is
-         released. *)
-    in
-    let share, private_ =
-      match (action : Action.t) with
-      | Adopt -> [], state.public
-      | Match -> match_ 0, state.private_
-      | Override -> match_ 1, state.private_
-      | Wait -> [], state.private_
-    in
-    BetweenActions
-      { private_; public = state.public; pending_private_to_public_messages = share }
-    |> return ~share
+      BeforeAction { public; private_ = state.private_ }
+    ;;
+
+    module Dagtools = Dagtools.Make (Block)
+
+    let prepare (BeforeAction state) event =
+      let public, private_, event =
+        match event with
+        | Append _ -> failwith "not implemented"
+        | Network x ->
+          (* simulate defender *)
+          N.update_head ~old:state.public x, state.private_, `Network
+        | ProofOfWork x ->
+          (* work on private chain *)
+          state.public, x, `ProofOfWork
+      in
+      let common = Dagtools.common_ancestor public private_ |> Option.get in
+      Observable { public; private_; common; event }
+    ;;
+
+    let prepare state = deliver_private_to_public_messages state |> prepare
+
+    let observe (Observable state) =
+      let open Observation in
+      let ca_height = data state.common |> height
+      and private_height = data state.private_ |> height
+      and public_height = data state.public |> height in
+      { private_blocks = private_height - ca_height
+      ; public_blocks = public_height - ca_height
+      ; diff_blocks = private_height - public_height
+      ; event = state.event
+      }
+    ;;
+
+    let apply (Observable state) action =
+      let parent vtx =
+        match parents vtx with
+        | [ x ] -> Some x
+        | _ -> None
+      in
+      let match_ offset =
+        let h =
+          (* height of to be released block *)
+          height (data state.public) + offset
+        in
+        (* look for to be released block backwards from private head *)
+        let rec f b = if height (data b) <= h then b else parent b |> Option.get |> f in
+        [ f state.private_ ]
+        (* NOTE: if private height is smaller target height, then private head is
+           released. *)
+      in
+      let share, private_ =
+        match (action : Action.t) with
+        | Adopt -> [], state.public
+        | Match -> match_ 0, state.private_
+        | Override -> match_ 1, state.private_
+        | Wait -> [], state.private_
+      in
+      BetweenActions
+        { private_; public = state.public; pending_private_to_public_messages = share }
+      |> return ~share
+    ;;
+  end
+
+  let attacker (type a) policy ((module V) : (a, data) view) : (a, data) node =
+    Node
+      (module struct
+        include Agent (V)
+
+        let handler s e =
+          let s = prepare s e in
+          observe s |> policy |> apply s
+        ;;
+      end)
   ;;
-end
 
-let attacker (type a) policy ((module V) : (a, data) view) : (a, data) node =
-  Node
-    (module struct
-      include Agent (V)
+  module Policies = struct
+    let honest o =
+      let open Observation in
+      let open Action in
+      if o.private_blocks > o.public_blocks
+      then Override
+      else if o.private_blocks < o.public_blocks
+      then Adopt
+      else Wait
+    ;;
 
-      let handler s e =
-        let s = prepare s e in
-        observe s |> policy |> apply s
-      ;;
-    end)
-;;
-
-module Policies = struct
-  let honest o =
-    let open Observation in
-    let open Action in
-    if o.private_blocks > o.public_blocks
-    then Override
-    else if o.private_blocks < o.public_blocks
-    then Adopt
-    else Wait
-  ;;
-
-  (* Patrik's ad-hoc strategy *)
-  let simple o =
-    let open Observation in
-    let open Action in
-    if o.public_blocks > 0
-    then if o.private_blocks < o.public_blocks then Adopt else Override
-    else Wait
-  ;;
-
-  (* Eyal and Sirer. Majority is not enough: Bitcoin mining is vulnerable. 2014. *)
-  let es_2014 o =
-    (* I interpret this from the textual description of the strategy. There is an
-       algorithmic version in the paper, but it depends on the observation whether the
-       last mined block is honest or not. *)
-    let open Observation in
-    let open Action in
-    if o.private_blocks < o.public_blocks
-    then (* 1. *) Adopt
-    else if o.public_blocks = 0 && o.private_blocks = 1
-    then (* 2. *) Wait
-    else if o.public_blocks = 1 && o.private_blocks = 1
-    then (* 3. *) Match
-    else if o.public_blocks = 1 && o.private_blocks = 2
-    then (* 4. *) Override
-    else if o.public_blocks = 2 && o.private_blocks = 1
-    then (* 5. Redundant: included in 1. *)
-      Adopt
-    else (
-      (* The attacker established a lead of more than two before: *)
-      let _ = () in
+    (* Patrik's ad-hoc strategy *)
+    let simple o =
+      let open Observation in
+      let open Action in
       if o.public_blocks > 0
-      then
-        if o.private_blocks - o.public_blocks = 1
-        then (* 6. *) Override
-        else (* 7. *) Match
-      else Wait)
-  ;;
+      then if o.private_blocks < o.public_blocks then Adopt else Override
+      else Wait
+    ;;
 
-  (* Sapirshtein, Sompolinsky, Zohar. Optimal Selfish Mining Strategies in Bitcoin.
-     2016. *)
-  let ssz_2016_sm1 o =
-    (* The authors rephrase the policy of ES'14 and call it SM1. Their version is much
-       shorter.
+    (* Eyal and Sirer. Majority is not enough: Bitcoin mining is vulnerable. 2014. *)
+    let es_2014 o =
+      (* I interpret this from the textual description of the strategy. There is an
+         algorithmic version in the paper, but it depends on the observation whether the
+         last mined block is honest or not. *)
+      let open Observation in
+      let open Action in
+      if o.private_blocks < o.public_blocks
+      then (* 1. *) Adopt
+      else if o.public_blocks = 0 && o.private_blocks = 1
+      then (* 2. *) Wait
+      else if o.public_blocks = 1 && o.private_blocks = 1
+      then (* 3. *) Match
+      else if o.public_blocks = 1 && o.private_blocks = 2
+      then (* 4. *) Override
+      else if o.public_blocks = 2 && o.private_blocks = 1
+      then (* 5. Redundant: included in 1. *)
+        Adopt
+      else (
+        (* The attacker established a lead of more than two before: *)
+        let _ = () in
+        if o.public_blocks > 0
+        then
+          if o.private_blocks - o.public_blocks = 1
+          then (* 6. *) Override
+          else (* 7. *) Match
+        else Wait)
+    ;;
 
-       The authors define an MDP to find better strategies for various parameters alpha
-       and gamma. We cannot reproduce this here in this module. Our RL framework should be
-       able to find these policies, though. *)
-    let open Observation in
-    let open Action in
-    match o.public_blocks, o.private_blocks with
-    | h, a when h > a -> Adopt
-    | 1, 1 -> Match
-    | h, a when h = a - 1 && h >= 1 -> Override
-    | _ (* Otherwise *) -> Wait
+    (* Sapirshtein, Sompolinsky, Zohar. Optimal Selfish Mining Strategies in Bitcoin.
+       2016. *)
+    let ssz_2016_sm1 o =
+      (* The authors rephrase the policy of ES'14 and call it SM1. Their version is much
+         shorter.
+
+         The authors define an MDP to find better strategies for various parameters alpha
+         and gamma. We cannot reproduce this here in this module. Our RL framework should
+         be able to find these policies, though. *)
+      let open Observation in
+      let open Action in
+      match o.public_blocks, o.private_blocks with
+      | h, a when h > a -> Adopt
+      | 1, 1 -> Match
+      | h, a when h = a - 1 && h >= 1 -> Override
+      | _ (* Otherwise *) -> Wait
+    ;;
+  end
+
+  let policies =
+    let open Collection in
+    let open Policies in
+    empty
+    |> add ~info:"emulate honest behaviour" "honest" honest
+    |> add ~info:"simple withholding policy" "simple" simple
+    |> add ~info:"Eyal and Sirer 2014" "eyal-sirer-2014" es_2014
+    |> add ~info:"Sapirshtein et al. 2016, SM1" "sapirshtein-2016-sm1" ssz_2016_sm1
   ;;
 end
-
-let policies =
-  let open Collection in
-  let open Policies in
-  empty
-  |> add ~info:"emulate honest behaviour" "honest" honest
-  |> add ~info:"simple withholding policy" "simple" simple
-  |> add ~info:"Eyal and Sirer 2014" "eyal-sirer-2014" es_2014
-  |> add ~info:"Sapirshtein et al. 2016, SM1" "sapirshtein-2016-sm1" ssz_2016_sm1
-;;

--- a/simulator/protocols/ssz_tools.ml
+++ b/simulator/protocols/ssz_tools.ml
@@ -8,7 +8,25 @@ module NormalizeObs = struct
         }
         -> int field
 
-  let to_float (type a) (t : a field) : a -> float =
+  let to_float_raw (type a) (t : a field) : a -> float =
+    match t with
+    | Bool -> fun b -> if b then 1. else 0.
+    | Discrete l ->
+      let l = List.mapi (fun i x -> x, float_of_int i) l in
+      fun x -> List.assoc x l
+    | UnboundedInt _ -> fun x -> float_of_int x
+  ;;
+
+  let of_float_raw (type a) (t : a field) : float -> a =
+    match t with
+    | Bool -> fun x -> x >= 0.5
+    | Discrete l ->
+      let arr = Array.of_list l in
+      fun x -> arr.(int_of_float x)
+    | UnboundedInt _ -> fun x -> int_of_float x
+  ;;
+
+  let to_float_unit (type a) (t : a field) : a -> float =
     match t with
     | Bool -> fun b -> if b then 1. else 0.
     | Discrete l ->
@@ -21,7 +39,7 @@ module NormalizeObs = struct
       fun x -> 0.5 +. (1. /. Float.pi *. Float.atan (float_of_int x /. float_of_int scale))
   ;;
 
-  let of_float (type a) (t : a field) : float -> a =
+  let of_float_unit (type a) (t : a field) : float -> a =
     match t with
     | Bool -> fun x -> x >= 0.5
     | Discrete l ->
@@ -40,8 +58,19 @@ module NormalizeObs = struct
         |> Float.to_int
   ;;
 
-  let low len = Array.make len 0.
-  let high len = Array.make len 1.
+  let of_float ~unit = if unit then of_float_unit else of_float_raw
+  let to_float ~unit = if unit then to_float_unit else to_float_raw
+
+  let range (type a) (t : a field) : float * float =
+    match t with
+    | Bool -> 0., 0.
+    | Discrete l -> 0., List.length l - 1 |> float_of_int
+    | UnboundedInt { non_negative = true; scale = _ } -> 0., Float.infinity
+    | UnboundedInt { non_negative = false; scale = _ } ->
+      Float.neg_infinity, Float.infinity
+  ;;
+
+  let range ~unit t = if unit then 0., 1. else range t
 end
 
 let event_to_string = function
@@ -50,10 +79,12 @@ let event_to_string = function
   | `Network -> "`Network"
 ;;
 
-let%test_module _ =
+let%test_module "normalize unit" =
   (module struct
     open NormalizeObs
 
+    let to_float x = to_float ~unit:true x
+    let of_float x = of_float ~unit:true x
     let t = Bool
 
     let%test "bool" = to_float t true |> of_float t = true
@@ -119,6 +150,80 @@ let%test_module _ =
     let%test "unbounded int scale 4" = to_float t 0 = 0.5
     let%test "unbounded int scale 4" = to_float t 4 = 0.75
     let%test "unbounded int scale 4" = to_float t max_int = 1.
+  end)
+;;
+
+let%test_module "normalize raw" =
+  (module struct
+    open NormalizeObs
+
+    let to_float x = to_float ~unit:false x
+    let of_float x = of_float ~unit:false x
+    let t = Bool
+
+    let%test "bool" = to_float t true |> of_float t = true
+    let%test "bool" = to_float t false |> of_float t = false
+
+    let t = Discrete [ `A; `B; `C ]
+
+    let%test "discrete" = to_float t `A |> of_float t = `A
+    let%test "discrete" = to_float t `B |> of_float t = `B
+    let%test "discrete" = to_float t `C |> of_float t = `C
+    let%test "discrete" = to_float t `A = 0.
+    let%test "discrete" = to_float t `C = 2.
+
+    let t = UnboundedInt { non_negative = true; scale = 1 }
+
+    let%test "unbounded int non_neg" = to_float t 0 |> of_float t = 0
+    let%test "unbounded int non_neg" = to_float t 1 |> of_float t = 1
+    let%test "unbounded int non_neg" = to_float t 2 |> of_float t = 2
+    let%test "unbounded int non_neg" = to_float t 256 |> of_float t = 256
+    let%test "unbounded int non_neg" = to_float t 0 = 0.
+    let%test "unbounded int non_neg" = to_float t 1 = 1.
+    let%test "unbounded int non_neg" = to_float t 42 = 42.
+
+    let t = UnboundedInt { non_negative = false; scale = 1 }
+
+    let%test "unbounded int" = to_float t 0 |> of_float t = 0
+    let%test "unbounded int" = to_float t 1 |> of_float t = 1
+    let%test "unbounded int" = to_float t 2 |> of_float t = 2
+    let%test "unbounded int" = to_float t 256 |> of_float t = 256
+    let%test "unbounded int" = to_float t (-1) |> of_float t = -1
+    let%test "unbounded int" = to_float t (-2) |> of_float t = -2
+    let%test "unbounded int" = to_float t (-256) |> of_float t = -256
+    let%test "unbounded int" = to_float t (-42) = -42.
+    let%test "unbounded int" = to_float t (-1) = -1.
+    let%test "unbounded int" = to_float t 0 = 0.
+    let%test "unbounded int" = to_float t 1 = 1.
+    let%test "unbounded int" = to_float t 42 = 42.
+
+    let t = UnboundedInt { non_negative = true; scale = 4 }
+
+    let%test "unbounded int non_neg scale 4" = to_float t 0 |> of_float t = 0
+    let%test "unbounded int non_neg scale 4" = to_float t 1 |> of_float t = 1
+    let%test "unbounded int non_neg scale 4" = to_float t 2 |> of_float t = 2
+    let%test "unbounded int non_neg scale 4" = to_float t 256 |> of_float t = 256
+    let%test "unbounded int non_neg scale 4" = to_float t (-1) |> of_float t = -1
+    let%test "unbounded int non_neg scale 4" = to_float t (-2) |> of_float t = -2
+    let%test "unbounded int non_neg scale 4" = to_float t (-256) |> of_float t = -256
+    let%test "unbounded int non_neg scale 4" = to_float t 0 = 0.
+    let%test "unbounded int non_neg scale 4" = to_float t 4 = 4.
+    let%test "unbounded int non_neg scale 4" = to_float t 42 = 42.
+
+    let t = UnboundedInt { non_negative = false; scale = 4 }
+
+    let%test "unbounded int scale 4" = to_float t 0 |> of_float t = 0
+    let%test "unbounded int scale 4" = to_float t 1 |> of_float t = 1
+    let%test "unbounded int scale 4" = to_float t 2 |> of_float t = 2
+    let%test "unbounded int scale 4" = to_float t 256 |> of_float t = 256
+    let%test "unbounded int scale 4" = to_float t (-1) |> of_float t = -1
+    let%test "unbounded int scale 4" = to_float t (-2) |> of_float t = -2
+    let%test "unbounded int scale 4" = to_float t (-256) |> of_float t = -256
+    let%test "unbounded int scale 4" = to_float t (-42) = -42.
+    let%test "unbounded int scale 4" = to_float t (-4) = -4.
+    let%test "unbounded int scale 4" = to_float t 0 = 0.
+    let%test "unbounded int scale 4" = to_float t 4 = 4.
+    let%test "unbounded int scale 4" = to_float t 42 = 42.
   end)
 ;;
 

--- a/simulator/protocols/tailstorm_june.ml
+++ b/simulator/protocols/tailstorm_june.ml
@@ -1,0 +1,393 @@
+open Cpr_lib
+
+(* This is an attempt to map Tailstorm(ll) as we had in in June, i.e., successful WandB
+   run 257 and git commit cc21ff0f3f, to the updated simulator infrastructure.
+
+   After satisfying the new simulator's requirements, the diff with tailstormll.ml is
+   rather small. It's probably wise to drop this implementation here to avoid redundancy.
+   But let's first reproduce WandB run 257 with this one. *)
+
+let incentive_schemes = [ `Block; `Constant; `Discount; `Hybrid; `Punish ]
+
+module type Parameters = sig
+  (** number of votes (= puzzle solutions) per block *)
+  val k : int
+
+  val incentive_scheme : [ `Block | `Constant | `Discount | `Hybrid | `Punish ]
+end
+
+module Make (Parameters : Parameters) = struct
+  open Parameters
+
+  let key =
+    let open Options in
+    Format.asprintf "tailstormjune-%i-%a" k pp incentive_scheme
+  ;;
+
+  let description =
+    Format.asprintf
+      "Tailstorm/ll (June '22 version) with k=%i and %a rewards"
+      Parameters.k
+      Options.pp
+      incentive_scheme
+  ;;
+
+  let info =
+    let open Info in
+    [ string "family" "tailstormjune"
+    ; int "k" k
+    ; Options.info "incentive_scheme" incentive_scheme
+    ]
+  ;;
+
+  type data =
+    { block : int
+    ; vote : int
+    ; miner : int option
+    }
+
+  let height h = h.block
+  let is_vote h = h.vote > 0
+  let is_block h = h.vote = 0
+  let progress x = (x.block * k) + x.vote |> float_of_int
+
+  let describe h =
+    let ty = if is_vote h then "vote" else "block" in
+    Printf.sprintf "%s (%i|%i)" ty h.block h.vote
+  ;;
+
+  let roots = [ { block = 0; vote = 0; miner = None } ]
+
+  module Referee (D : BlockDAG with type data = data) = struct
+    include D
+
+    let info x =
+      let x = data x in
+      let open Info in
+      if is_vote x
+      then [ string "kind" "vote"; int "height" x.block; int "depth" x.vote ]
+      else [ string "kind" "summary"; int "height" x.block ]
+    ;;
+
+    let label x =
+      let x = data x in
+      if is_vote x
+      then Printf.sprintf "summary %i" x.block
+      else Printf.sprintf "vote (%i|%i)" x.block x.vote
+    ;;
+
+    let dag_fail (type a) vertices msg : a =
+      let meta x = [ Info.string "label" (label x) ] in
+      raise_invalid_dag meta vertices msg
+    ;;
+
+    let is_vote x = is_vote (data x)
+    let is_block x = is_block (data x)
+    let height x = height (data x)
+    let progress x = progress (data x)
+
+    let rec last_block x =
+      if is_block x
+      then x
+      else (
+        match parents x with
+        | [ x ] -> last_block x
+        | parents ->
+          dag_fail (x :: parents) "last_block: votes have one parent by dag_validity")
+    ;;
+
+    (* smaller is better *)
+    let compare_votes_in_block =
+      let get x =
+        let d = data x
+        and hash = pow x |> Option.value ~default:min_pow in
+        d.vote, hash
+      and ty = Compare.(tuple (neg int) compare_pow) in
+      Compare.(by ty get)
+    ;;
+
+    module BlockSet = Set.Make (Block)
+
+    let acc_votes unfold l =
+      let open BlockSet in
+      let rec f acc stack l =
+        match l, stack with
+        | [], [] -> acc
+        | [], hd :: tl -> f acc tl hd
+        | hd :: tl, stack when is_vote hd -> f (add hd acc) (unfold hd :: stack) tl
+        | _ :: tl, stack -> f acc stack tl
+      in
+      f empty [] l
+    ;;
+
+    let validity vertex =
+      let child = data vertex in
+      child.block >= 0
+      && child.vote >= 0
+      && child.vote < k
+      && pow vertex |> Option.is_some
+      && child.miner |> Option.is_some
+      &&
+      match is_vote vertex, parents vertex with
+      | true, [ p ] ->
+        (* child is vote *)
+        let parent = data p in
+        child.block = parent.block && child.vote = parent.vote + 1
+      | false, p :: votes ->
+        (* child is block *)
+        let parent = data p in
+        let unique_votes = acc_votes parents votes |> BlockSet.cardinal
+        and sorted_votes = Compare.is_sorted ~unique:true compare_votes_in_block votes in
+        is_block p
+        && sorted_votes
+        && List.for_all is_vote votes
+        && unique_votes = k - 1
+        && child.block = parent.block + 1
+        && child.vote = 0
+      | _ -> false
+    ;;
+
+    (** better is bigger *)
+    let compare_blocks =
+      let open Compare in
+      let cmp =
+        by (tuple int int) (fun x ->
+            let x = data x in
+            x.block, x.vote)
+      in
+      skip_eq Block.eq cmp
+    ;;
+
+    let winner l =
+      List.map last_block l
+      |> Compare.first (Compare.neg compare_blocks) 1
+      |> Option.get
+      |> List.hd
+    ;;
+
+    let precursor this = List.nth_opt (parents this) 0
+
+    let assign c x =
+      match (data x).miner with
+      | Some x -> [ x, c ]
+      | None -> []
+    ;;
+
+    let constant_block c x = if is_block x then assign c x else []
+
+    let reward' ~max_reward_per_block ~discount ~punish x =
+      let k = float_of_int k in
+      let c = max_reward_per_block /. k in
+      if is_block x
+      then (
+        match parents x |> List.filter is_vote with
+        | [] -> (* Either genesis or k=1 *) []
+        | first :: _ as all ->
+          let depth = (data first).vote in
+          let r = if discount then (float_of_int depth +. 1.) /. k *. c else c in
+          let votes =
+            if punish
+            then BlockSet.add x (acc_votes parents [ first ])
+            else BlockSet.add x (acc_votes parents all)
+          in
+          BlockSet.elements votes |> List.concat_map (assign r))
+      else []
+    ;;
+
+    let reward =
+      let reward = reward' ~max_reward_per_block:(float_of_int k) in
+      match incentive_scheme with
+      | `Block -> constant_block (float_of_int k)
+      | `Constant -> reward ~discount:false ~punish:false
+      | `Discount -> reward ~discount:true ~punish:false
+      | `Punish -> reward ~discount:false ~punish:true
+      | `Hybrid -> reward ~discount:true ~punish:true
+    ;;
+  end
+
+  let referee (type a) (module D : BlockDAG with type block = a and type data = data)
+      : (a, data) referee
+    =
+    (module Referee (D))
+  ;;
+
+  module Honest (V : View with type data = data) = struct
+    include V
+    open Referee (V)
+
+    type state = block
+
+    let preferred state = last_block state
+
+    let init ~roots =
+      match roots with
+      | [ genesis ] -> genesis
+      | roots -> dag_fail roots "init: expected single root"
+    ;;
+
+    let appended_by_me x =
+      match visibility x with
+      | `Received -> false
+      | `Withheld | `Released -> true
+    ;;
+
+    let quorum_old for_block =
+      (* look through sub blocks (votes) and assemble quorum if possible. This version
+         picks the longest branches first. If a branches does not fit into the quorum, it
+         is cut down until it fits.
+
+         The chosen sub blocks are not always optimal for the miner of the block. Thus
+         this implementation does not align with George's description of Tailstorm.*)
+      let rec f acc n q l =
+        if n = k - 1
+        then Some (List.rev q)
+        else (
+          match l with
+          | [] -> None
+          | hd :: tl ->
+            let fresh, n_fresh =
+              BlockSet.fold
+                (fun el (fresh, n_fresh) ->
+                  if BlockSet.mem el acc
+                  then fresh, n_fresh
+                  else BlockSet.add el fresh, n_fresh + 1)
+                (acc_votes parents [ hd ])
+                (BlockSet.empty, 0)
+            in
+            let n' = n + n_fresh in
+            if n' > k - 1 || n_fresh < 1
+            then (* quorum would grow to big *) f acc n q tl
+            else f (BlockSet.union fresh acc) n' (hd :: q) tl)
+      in
+      acc_votes children (children for_block)
+      |> BlockSet.elements
+      |> List.sort
+           Compare.(
+             by
+               (tuple (neg int) (tuple int float))
+               (fun x ->
+                 (data x).vote, ((if appended_by_me x then 0 else 1), visible_since x)))
+      |> f BlockSet.empty 0 []
+      |> Option.map
+           (List.sort
+              Compare.(
+                by
+                  (tuple (neg int) compare_pow)
+                  (fun x ->
+                    let d = data x
+                    and hash = pow x |> Option.value ~default:max_pow in
+                    d.vote, hash)))
+    ;;
+
+    let quorum for_block =
+      (* look through the sub blocks (votes) and assemble a quorum if possible. This
+         version tries to select the sub blocks that maximize a miner's own rewards.
+
+         We first find all branches of depth k-1 or less. We then sort the branches by own
+         reward, assuming that the branch will be confirmed in the future. We then add the
+         most valuable branch to the quorum.
+
+         If some (= k') sub blocks are missing after the first iteration, we search for
+         all remaining branches that would add 'k or less sub blocks. We sort the branches
+         by the amount of reward they would add. We add the most valuable branch an
+         reiterate until enough sub blocks are added.
+
+         TODO. For now, we assume constant reward per proof-of-work. Handling the other
+         reward schemes correctly requires a restructuring of the code: reward function
+         must become an argument of the protocol. *)
+      let ht = Hashtbl.create (2 * k)
+      and acc = ref []
+      and n = ref (k - 1) in
+      let included x =
+        Hashtbl.mem ht x
+        (* tailstormll.ml has a version w/o hashtbl. Should be preferred because this
+           hashes blocks including parents and children recursively *)
+      in
+      let include_ x =
+        assert (not (included x));
+        acc := x :: !acc;
+        acc_votes parents [ x ]
+        |> BlockSet.iter (fun x ->
+               if not (included x)
+               then (
+                 Hashtbl.replace ht x true;
+                 decr n))
+      and reward ?(all = false) x =
+        let i = ref 0 in
+        let () =
+          acc_votes parents [ x ]
+          |> BlockSet.iter (fun x ->
+                 if (not (included x)) && (all || appended_by_me x) then incr i)
+        in
+        !i
+      in
+      let rec loop () =
+        assert (!n >= 0);
+        if !n > 0
+        then (
+          acc_votes children (children for_block)
+          |> BlockSet.elements
+          |> List.filter (fun x -> not (included x))
+          |> (* calculate own and overall reward for branch *)
+          List.map (fun x -> x, reward x, reward ~all:true x)
+          |> (* ensure branch fits into quorum *) List.filter (fun (_, _, x) -> x <= !n)
+          |> (* prefer own reward, then overall reward *)
+          List.sort
+            Compare.(
+              by int (fun (_, x, _) -> x) |> neg $ (by int (fun (_, _, x) -> x) |> neg))
+          |> function
+          | [] -> None (* no branches left, not enough votes *)
+          | (x, _, _) :: _ ->
+            (* add best branch, continue *)
+            include_ x;
+            loop ())
+        else
+          (* quorum complete. Ensure that it satisfies quorum validity *)
+          Some (List.sort compare_votes_in_block !acc)
+      in
+      loop ()
+    ;;
+
+    let puzzle_payload preferred =
+      let block = last_block preferred in
+      match quorum block with
+      | Some q ->
+        { parents = block :: q
+        ; sign = false
+        ; data = { block = height block + 1; vote = 0; miner = Some my_id }
+        }
+      | None ->
+        let votes =
+          acc_votes children (children block)
+          |> BlockSet.elements
+          |> List.sort compare_votes_in_block
+        in
+        let parent =
+          match votes with
+          | hd :: _ -> hd
+          | _ -> block
+        in
+        { parents = [ parent ]
+        ; sign = false
+        ; data =
+            { block = height block; vote = (data parent).vote + 1; miner = Some my_id }
+        }
+    ;;
+
+    let handler preferred = function
+      | Append _x -> failwith "not implemented"
+      | ProofOfWork v -> { state = v; share = [ v ]; append = [] }
+      | Network consider ->
+        (* Prefer longest chain of votes after longest chain of blocks *)
+        let p = data preferred
+        and c = data consider in
+        if c.block > p.block || (c.block = p.block && c.vote > p.vote)
+        then { state = consider; share = []; append = [] }
+        else { state = preferred; share = []; append = [] }
+    ;;
+  end
+
+  let honest (type a) ((module V) : (a, data) view) : (a, data) node =
+    Node (module Honest (V))
+  ;;
+end

--- a/simulator/protocols/tailstorm_june_ssz.ml
+++ b/simulator/protocols/tailstorm_june_ssz.ml
@@ -1,0 +1,439 @@
+open Cpr_lib
+
+(* This is an attempt to map Tailstorm(ll) as we had in in June, i.e., successful WandB
+   run 257 and git commit cc21ff0f3f, to the updated simulator infrastructure.
+
+   Diff to tailstormll_ssz.ml is significant. Maybe keep this as reference even if we drop
+   (largely redundant) tailstorm_june.ml. Let's first see, whether we can reproduce WandB
+   run 257 against this attack space. *)
+
+module Make (Parameters : Tailstorm_june.Parameters) = struct
+  module Protocol = Tailstorm_june.Make (Parameters)
+  open Protocol
+
+  let key = "ssz"
+  let info = "SSZ'16-like attack space"
+
+  module Observation = struct
+    type t =
+      { public_blocks : int (** number of blocks after common ancestor *)
+      ; public_depth : int (** number of votes confirming the leading block *)
+      ; private_blocks : int (** number of blocks after common ancestor *)
+      ; private_depth : int (** number of votes confirming the leading block *)
+      ; diff_blocks : int (** private_blocks - public_blocks *)
+      ; diff_depth : int (** private_votes - public_votes *)
+      }
+    [@@deriving fields]
+
+    let length = List.length Fields.names
+
+    let _low =
+      { public_blocks = 0
+      ; public_depth = 0
+      ; private_blocks = 0
+      ; private_depth = 0
+      ; diff_blocks = min_int
+      ; diff_depth = min_int
+      }
+    ;;
+
+    let _high =
+      { public_blocks = max_int
+      ; public_depth = max_int
+      ; private_blocks = max_int
+      ; private_depth = max_int
+      ; diff_blocks = max_int
+      ; diff_depth = max_int
+      }
+    ;;
+
+    let to_floatarray t =
+      let a = Float.Array.make length Float.nan in
+      let set conv i field =
+        Float.Array.set a i (Fieldslib.Field.get field t |> conv);
+        i + 1
+      in
+      let int = set float_of_int in
+      let _ =
+        Fields.fold
+          ~init:0
+          ~public_blocks:int
+          ~public_depth:int
+          ~private_blocks:int
+          ~private_depth:int
+          ~diff_blocks:int
+          ~diff_depth:int
+      in
+      a
+    ;;
+
+    let of_floatarray =
+      let get conv _ i = (fun a -> Float.Array.get a i |> conv), i + 1 in
+      let int = get int_of_float in
+      fst
+        (Fields.make_creator
+           0
+           ~public_blocks:int
+           ~public_depth:int
+           ~private_blocks:int
+           ~private_depth:int
+           ~diff_blocks:int
+           ~diff_depth:int)
+    ;;
+
+    let to_string t =
+      let conv to_s field =
+        Printf.sprintf
+          "%s: %s"
+          (Fieldslib.Field.name field)
+          (to_s (Fieldslib.Field.get field t))
+      in
+      let int = conv string_of_int in
+      Fields.to_list
+        ~public_blocks:int
+        ~public_depth:int
+        ~private_blocks:int
+        ~private_depth:int
+        ~diff_blocks:int
+        ~diff_depth:int
+      |> String.concat "\n"
+    ;;
+
+    let%test _ =
+      let run _i =
+        let t =
+          { public_blocks = Random.bits ()
+          ; public_depth = Random.bits ()
+          ; private_blocks = Random.bits ()
+          ; private_depth = Random.bits ()
+          ; diff_blocks = Random.bits ()
+          ; diff_depth = Random.bits ()
+          }
+        in
+        t = (to_floatarray t |> of_floatarray)
+      in
+      List.init 50 run |> List.for_all (fun x -> x)
+    ;;
+  end
+
+  module Action = Ssz_tools.Action8
+
+  module Agent (V : View with type data = data) = struct
+    open Protocol.Referee (V)
+    include V
+    module Dagtools = Dagtools.Make (Block)
+
+    module State : sig
+      open V
+
+      type t = private
+        { public : block (* defender's preferred block *)
+        ; private_ : block (* attacker's preferred block *)
+        ; common : block (* common chain *)
+        ; epoch : [ `Proceed | `Prolong ]
+              (* Proceed: the attacker considers the defender's votes that extend on his
+                 preferred block when building a new block.
+
+                 Prolong: the attacker prolongs the current epoch until he can form a
+                 block that does not reference any defender votes. *)
+        ; pending_private_to_public_messages : block list
+        }
+
+      val init : epoch:[ `Proceed | `Prolong ] -> block -> t
+
+      (* Set fields in state; updates common chain *)
+      val update
+        :  ?public:block
+        -> ?private_:block
+        -> ?epoch:[ `Proceed | `Prolong ]
+        -> ?pending_private_to_public_messages:block list
+        -> t
+        -> t
+    end = struct
+      open V
+
+      type t =
+        { public : block
+        ; private_ : block
+        ; common : block
+        ; epoch : [ `Proceed | `Prolong ]
+        ; pending_private_to_public_messages : block list
+        }
+
+      let init ~epoch x =
+        { public = x
+        ; private_ = x
+        ; common = x
+        ; epoch
+        ; pending_private_to_public_messages = []
+        }
+      ;;
+
+      (* call this whenever public or private_ changes *)
+      let set_common state =
+        let common = Dagtools.common_ancestor state.public state.private_ in
+        assert (Option.is_some common) (* all our protocols maintain this invariant *);
+        { state with common = Option.get common }
+      ;;
+
+      let update ?public ?private_ ?epoch ?pending_private_to_public_messages t =
+        set_common
+          { public = Option.value ~default:t.public public
+          ; private_ = Option.value ~default:t.private_ private_
+          ; epoch = Option.value ~default:t.epoch epoch
+          ; common = t.common
+          ; pending_private_to_public_messages =
+              Option.value
+                ~default:t.pending_private_to_public_messages
+                pending_private_to_public_messages
+          }
+      ;;
+    end
+
+    type state = State.t
+    type observable_state = Observable of state
+
+    let preferred (s : state) = last_block s.private_
+
+    let init ~roots =
+      let module N = Honest (V) in
+      N.init ~roots |> State.init ~epoch:`Prolong
+    ;;
+
+    (* the attacker emulates a defending node. This is the local_view of the defender *)
+
+    let public_visibility _state x =
+      match visibility x with
+      | `Received | `Released -> true
+      | `Withheld -> false
+    ;;
+
+    let public_view s : (block, data) view =
+      (module struct
+        include V
+
+        let children x = children x |> List.filter (public_visibility s)
+        let parents x = parents x |> List.filter (public_visibility s)
+
+        let data x =
+          if not (public_visibility s x) then failwith "invalid access / public view";
+          data x
+        ;;
+
+        let visibility _x = `Received
+
+        (** The attacker simulates an honest node on the public view. This node should not
+           interpret attacker vertices as own vertices. *)
+        let my_id = -1
+      end)
+    ;;
+
+    (* the attacker works on a subset of the total information: he ignores new defender
+       blocks *)
+
+    let appended_by_me x =
+      match visibility x with
+      | `Received -> false
+      | `Withheld | `Released -> true
+    ;;
+
+    let private_visibility (s : state) vertex =
+      (* defender votes for the attacker's preferred block *)
+      (* || anything mined by the attacker *)
+      (* || anything on the common chain *)
+      (s.epoch = `Proceed
+      && is_vote vertex
+      && Block.eq (last_block vertex) (last_block s.private_))
+      || appended_by_me vertex
+      || Block.partial_compare s.common vertex >= 0
+    ;;
+
+    let private_view (s : state) : _ view =
+      (module struct
+        include V
+
+        let children x = children x |> List.filter (private_visibility s)
+        let parents x = parents x |> List.filter (private_visibility s)
+      end)
+    ;;
+
+    (* the attacker emulates a defending node. This describes the defender node *)
+    let handle_public (s : state) event =
+      let (module V) = public_view s in
+      let open Honest (V) in
+      let public = (handler s.public event).state in
+      State.update ~public s
+    ;;
+
+    (* this describes the attacker node *)
+    let handle_private (s : state) event =
+      let (module V) = private_view s in
+      let open Honest (V) in
+      let private_ = (handler s.private_ event).state in
+      State.update ~private_ s
+    ;;
+
+    let puzzle_payload (s : state) =
+      let (module Private) = private_view s in
+      let module N = Honest (Private) in
+      N.puzzle_payload (last_block s.private_)
+    ;;
+
+    let prepare (state : state) event =
+      let state =
+        let pending = state.pending_private_to_public_messages in
+        List.fold_left
+          (fun state msg -> handle_public state (Network msg))
+          (State.update ~pending_private_to_public_messages:[] state)
+          pending
+      in
+      match event with
+      | Append _ -> failwith "not implemented"
+      | ProofOfWork x ->
+        assert (private_visibility state x);
+        (* work on private chain *)
+        handle_private state event
+      | Network x ->
+        let state =
+          (* simulate defender *)
+          handle_public state event
+        in
+        (* deliver visible (not ignored) messages *)
+        if private_visibility state x then handle_private state event else state
+    ;;
+
+    let prepare s e = Observable (prepare s e)
+
+    let observe (Observable s) =
+      let open Observation in
+      let private_depth = (data s.private_).vote
+      and public_depth = (data s.public).vote in
+      let ca_height = height s.common
+      and private_height = height s.private_
+      and public_height = height s.public in
+      { private_blocks = private_height - ca_height
+      ; public_blocks = public_height - ca_height
+      ; diff_blocks = private_height - public_height
+      ; private_depth
+      ; public_depth
+      ; diff_depth = private_depth - public_depth
+      }
+    ;;
+
+    let interpret (s : state) action =
+      let parent n =
+        match parents n with
+        | hd :: _ -> Some hd
+        | _ -> None
+      in
+      let release kind =
+        (* find node to be released backwards from private head *)
+        let rec h x x' =
+          let d = compare_blocks x s.public in
+          if d <= 0
+          then (
+            match kind with
+            | `Override -> x'
+            | `Match -> x)
+          else h (parent x |> Option.get) x
+        in
+        [ h s.private_ s.private_ ]
+        (* NOTE: if private height is smaller public height, then private head is marked
+           for release. *)
+      in
+      match (action : Action.t) with
+      | Adopt_Proceed -> [], State.update ~epoch:`Proceed ~private_:s.public s
+      | Adopt_Prolong -> [], State.update ~epoch:`Prolong ~private_:s.public s
+      | Match_Proceed -> release `Match, State.update ~epoch:`Proceed s
+      | Match_Prolong -> release `Match, State.update ~epoch:`Prolong s
+      | Override_Proceed -> release `Override, State.update ~epoch:`Proceed s
+      | Override_Prolong -> release `Override, State.update ~epoch:`Prolong s
+      | Wait_Proceed -> [], State.update ~epoch:`Proceed s
+      | Wait_Prolong -> [], State.update ~epoch:`Prolong s
+    ;;
+
+    let conclude (pending_private_to_public_messages, state) =
+      { share = pending_private_to_public_messages
+      ; state = State.update ~pending_private_to_public_messages state
+      ; append = []
+      }
+    ;;
+
+    let apply (Observable state) action = interpret state action |> conclude
+  end
+
+  let attacker (type a) policy ((module V) : (a, data) view) : (a, data) node =
+    Node
+      (module struct
+        include Agent (V)
+
+        let handler s e =
+          let s = prepare s e in
+          observe s |> policy |> apply s
+        ;;
+      end)
+  ;;
+
+  module Policies = struct
+    let honest o =
+      let open Observation in
+      let open Action in
+      if o.public_blocks > 0 then Adopt_Proceed else Override_Proceed
+    ;;
+
+    let release_block o =
+      let open Observation in
+      let open Action in
+      if o.private_blocks < o.public_blocks
+      then Adopt_Proceed
+      else if o.private_blocks > o.public_blocks
+      then Override_Proceed
+      else Wait_Proceed
+    ;;
+
+    let override_block o =
+      let open Observation in
+      let open Action in
+      if o.private_blocks < o.public_blocks
+      then Adopt_Proceed
+      else if o.private_blocks = 0 && o.public_blocks = 0
+      then Wait_Proceed
+      else if o.public_blocks = 0
+      then Wait_Proceed
+      else Override_Proceed
+    ;;
+
+    let override_catchup o =
+      let open Observation in
+      let open Action in
+      if o.private_blocks < o.public_blocks
+      then Adopt_Proceed
+      else if o.private_blocks = 0 && o.public_blocks = 0
+      then Wait_Proceed
+      else if o.public_blocks = 0
+      then Wait_Proceed
+      else if o.private_depth = 0 && o.private_blocks = o.public_blocks + 1
+      then Override_Proceed
+      else if o.public_blocks = o.private_blocks && o.private_depth = o.public_depth + 1
+      then Override_Proceed
+      else if o.private_blocks - o.public_blocks > 10
+              (* fork can become really deep for strong attackers. Cut-off shortens time
+                 spent in common ancestor computation. *)
+      then Override_Proceed
+      else Wait_Proceed
+    ;;
+  end
+
+  let policies =
+    let open Collection in
+    let open Policies in
+    empty
+    |> add ~info:"emulate honest behaviour" "honest" honest
+    |> add ~info:"release private block a.s.a.p." "release-block" release_block
+    |> add ~info:"override public block a.s.a.p." "override-block" override_block
+    |> add
+         ~info:"override public head just before defender catches up"
+         "override-catchup"
+         override_catchup
+  ;;
+end

--- a/simulator/protocols/tailstorm_ssz.ml
+++ b/simulator/protocols/tailstorm_ssz.ml
@@ -1,11 +1,22 @@
 open Cpr_lib
 
-module Make (Parameters : Tailstorm.Parameters) = struct
+module type Parameters = sig
+  include Tailstorm.Parameters
+  include Nakamoto_ssz.Parameters
+end
+
+module Make (Parameters : Parameters) = struct
+  open Parameters
   module Protocol = Tailstorm.Make (Parameters)
   open Protocol
 
-  let key = "ssz"
-  let info = "SSZ'16-like attack space"
+  let key = Format.asprintf "ssz-%s" (if unit_observation then "unitobs" else "rawobs")
+
+  let info =
+    Format.asprintf
+      "SSZ'16-like attack space with %s observations"
+      (if unit_observation then "unit" else "raw")
+  ;;
 
   module Observation = struct
     type t =
@@ -45,13 +56,40 @@ module Make (Parameters : Tailstorm.Parameters) = struct
 
     let length = List.length Fields.names
 
+    let low, high =
+      let low, high = Float.Array.make length 0., Float.Array.make length 0. in
+      let set spec i _field =
+        let l, h = Ssz_tools.NormalizeObs.range ~unit:unit_observation spec in
+        Float.Array.set low i l;
+        Float.Array.set high i h;
+        i + 1
+      in
+      let _ =
+        let open Normalizers in
+        Fields.fold
+          ~init:0
+          ~public_blocks:(set public_blocks)
+          ~private_blocks:(set private_blocks)
+          ~diff_blocks:(set diff_blocks)
+          ~public_votes:(set public_votes)
+          ~private_votes_inclusive:(set private_votes_inclusive)
+          ~private_votes_exclusive:(set private_votes_exclusive)
+          ~public_depth:(set public_depth)
+          ~private_depth_inclusive:(set private_depth_inclusive)
+          ~private_depth_exclusive:(set private_depth_exclusive)
+          ~event:(set event)
+      in
+      low, high
+    ;;
+
     let to_floatarray t =
       let a = Float.Array.make length Float.nan in
       let set spec i field =
         Float.Array.set
           a
           i
-          (Fieldslib.Field.get field t |> Ssz_tools.NormalizeObs.to_float spec);
+          (Fieldslib.Field.get field t
+          |> Ssz_tools.NormalizeObs.to_float ~unit:unit_observation spec);
         i + 1
       in
       let _ =
@@ -74,7 +112,10 @@ module Make (Parameters : Tailstorm.Parameters) = struct
 
     let of_floatarray =
       let get spec _ i =
-        (fun a -> Float.Array.get a i |> Ssz_tools.NormalizeObs.of_float spec), i + 1
+        ( (fun a ->
+            Float.Array.get a i
+            |> Ssz_tools.NormalizeObs.of_float ~unit:unit_observation spec)
+        , i + 1 )
       in
       let open Normalizers in
       fst

--- a/simulator/protocols/tailstormll_ssz.ml
+++ b/simulator/protocols/tailstormll_ssz.ml
@@ -1,11 +1,17 @@
 open Cpr_lib
 
-module Make (Parameters : Tailstormll.Parameters) = struct
+module Make (Parameters : Tailstorm_ssz.Parameters) = struct
+  open Parameters
   module Protocol = Tailstormll.Make (Parameters)
   open Protocol
 
-  let key = "ssz"
-  let info = "SSZ'16-like attack space"
+  let key = Format.asprintf "ssz-%s" (if unit_observation then "unitobs" else "rawobs")
+
+  let info =
+    Format.asprintf
+      "SSZ'16-like attack space with %s observations"
+      (if unit_observation then "unit" else "raw")
+  ;;
 
   module Tailstorm_ssz = Tailstorm_ssz.Make (Parameters)
   module Observation = Tailstorm_ssz.Observation


### PR DESCRIPTION
In June we had successful training runs against Tailstorm(ll) discount on an alpha schedule list. We're not able to reproduce this against the new Tailstorm. To rule out any problems we want to reproduce the June results with the new simulator. **This PR re-adds the old protocol in the new simulator.**

As mentioned at the top of tailstorm_june.ml, the diff to tailstomll.ml is very small. Even if we keep the attack space tailstorm_june_ssz.ml for future reference, we probably still want to get rid of the protocol tailstorm_june.

The june version of the protocol does not support observation normalization to the unit interval. **This PR makes observation normalization optional**.